### PR TITLE
feat: 确定性 frontmatter 引号修复，免去 ingest 最高频自愈轮

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@
 
 ## [Unreleased]
 
+### 新增
+
+- **确定性 frontmatter 引号修复(免去 ingest 最高频自愈轮)** —— 写门禁最常见的自愈触发器是
+  `frontmatter.unparsable`(字符串值尤其 `title` 引号写坏:双引号套双引号 / 坏单引号 → 整块 YAML 解析
+  失败),而每轮自愈 = 一整个额外 Agentao 子进程(冷启动 + LLM)。新增 `guanlan/fmrepair.py`:零-LLM 确定性
+  把**有成对外引号**的失败标量剥外引号后单引号重包、整块复验为 mapping 后**逐字节落盘**,返回写前原字节。
+  接入 `gate.run_guarded_write_result`(**仅 page_guard 路径**:ingest / query --backfill / audit;heal
+  跳过以守其逐字节不变契约):修后用**真 `enforce_write_result` 重判**,仍出现在新阻断违规里的修复页一律
+  回滚到原字节——验收判据即门禁本身(run_check + 源不回退 + raw 完整性),只保留真省下自愈轮的修复、决不留
+  半成品写。安全闸:拒符号链接页 / 父目录符号链接越界、逐字节 I/O(不改 CRLF)、只修首尾成对引号、非 UTF-8
+  解码失败吞掉交自愈。**无新命令 / 无新退出码 / 无新依赖**;守于 `tests/test_fmrepair.py` +
+  `tests/test_gate.py`,设计见 `docs/ingest-frontmatter-自愈消除.md`。
+
 ### 修复
 
 - **README 图片/链接改用绝对 URL(修 PyPI 渲染)** —— PyPI 长描述(`pyproject` `readme = "README.md"`)

--- a/docs/ingest-frontmatter-自愈消除.md
+++ b/docs/ingest-frontmatter-自愈消除.md
@@ -1,0 +1,91 @@
+# 确定性 frontmatter 引号修复（消除最常见的写门禁自愈轮，零 LLM）
+
+> 纯性能微改、**不单列里程碑编号**（同 finding 因果排序、P4.11 那种小条目处理）。源自
+> 「ingest 性能优化」摸排：写门禁的**有界自愈**是 ingest 耗时的最大单一杠杆，而触发它的
+> 违规绝大多数是确定性可修的引号写坏——把这条最高频触发器零-LLM 消掉。
+
+## 0. 缺口
+
+写门禁（`gate.run_guarded_write_result`）每发现一条**本次新引入的阻断性违规**，就把清单回喂
+同一 Agent 就地修，**每轮自愈 = 一整个额外的 Agentao 子进程**（冷启动 + LLM 推理，最多 2 轮
+→ 最坏 3× LLM 成本）。而触发自愈的阻断性违规里，绝大多数是 **`frontmatter.unparsable`**——
+字符串值（尤其 `title`）把引号写坏（双引号套双引号 `title: "他说"你好""` / 坏单引号）导致整块
+YAML 解析失败（`pages.parse_frontmatter` 严格档报 fatal）。
+
+这一类**确定性可修**：坏的只是引号转义，意图明确是字符串、可恢复（剥一层外引号 → 改用单引号
+重包、内部 `'` 翻倍）。让宿主在 enforce 后、自愈循环前先确定性修一道，**用一次廉价的 Python
+重判换掉一整轮 LLM 自愈**。
+
+## 1. 落法
+
+新模块 `guanlan/fmrepair.py`（仿 `provenance.py`：宿主侧专项确定性 frontmatter 操作）。
+`repair_unparsable_pages(root, violations)` 对门禁违规集里 `kind=="frontmatter.unparsable"` 的页逐页
+`repair_page_frontmatter` —— 严格档确认是 unparsable → `_requote_block` 把**有成对外引号**（首尾同为
+`"` 或 `'`）的解析失败标量值剥外引号后改用单引号重包 → 整块复验为 mapping 后 **逐字节 I/O 落盘** →
+**返回写前原字节**（供门禁回滚）。**它只负责「能解析为 mapping 就落盘」，不判定该页是否真的全清**。
+复用 `pages.split_frontmatter` / `pages.parse_frontmatter`，不另写 YAML 解析。
+
+**「修完是否真省下自愈轮」由门禁裁定——验收判据就是门禁本身**（决不漏校验，见 §2.1）。接入
+`gate.run_guarded_write_result`：首次 `enforce_write_result` 后、有界自愈 `while` 前——
+
+```python
+if page_guard and gate.kind == "check_failed":
+    written = repair_unparsable_pages(root, gate.violations)          # {页: 原字节}
+    if written:
+        probe = enforce_write_result(root, before, first_result, page_before=page_before, baseline=baseline)
+        stuck = {rel for rel in written if any(v.page == rel for v in probe.violations)}
+        for rel in stuck:                                             # 仍阻断 → 回滚到原字节
+            (Path(root) / rel).write_bytes(written[rel])
+        kept = [rel for rel in sorted(written) if rel not in stuck]
+        if kept:
+            print(f"✓ 确定性修正 {len(kept)} 页 frontmatter 引号（免去自愈轮）", file=sys.stderr)
+        gate = enforce_write_result(...) if stuck else probe          # 有回滚才重判，否则 probe 即终态
+```
+
+修不动/回滚的残留照样进下面的自愈 `while`。**仅 `page_guard` 路径（ingest / `query --backfill` / audit）
+启用**；`page_guard=False` 的 **heal 跳过**——heal 直调本核心、契约是「逐字节不变 + 越界写审计」，不该
+被宿主改页，故不参与修复以保其行为不变。
+
+## 2. 边界与安全闸（硬约束）
+
+这让宿主**首次启发式改写 Agent 拥有的 `wiki/` 内容**。当前不变量是「宿主只校验、Agent 才写」，
+唯一先例是 `ingest._stamp_source_digest` 盖 `raw_digest`（**追加键**，非**修内容**）。下列闸把风险
+压到「**最差等于现状**」：
+
+1. **事务性落盘 + 门禁重判 + 回滚（worst = status quo 的核心闸）**：修引号落盘后，用**真
+   `enforce_write_result`**（= 门禁自身）重判，**仍出现在其新阻断违规里的修复页一律回滚到原字节**，
+   只保留**真省下自愈轮**的修复、决不留半成品写。**为何让门禁判而非写前逐项预判 / 也非自跑 `run_check`**：
+   原页 unparsable 时 meta=None 使首轮门禁**跳过本页的逐页与跨页校验**，被掩盖的不止 `bad_type`
+   （`tags: "a"b"`）、`sources.unresolved`、**跨页** `aliases.collides_stem`/`aliases.duplicate`，**还有
+   `run_check` 根本看不见的 page_guard 专属 `sources.dropped`（源不回退）**——逐项枚举校验器必漏，连
+   `run_check` 都不够（它不含源不回退）。**唯一不漏的判据就是门禁本身**，故验收直接复用 `enforce_write_result`
+   的结论（`probe.violations` 已是阻断+增量过滤面，断链作警告不入内、不会误回滚含前向引用 `[[X]]` 的新页）。
+   `probe` 反映回滚前状态，有回滚则再 `enforce` 一次得终态、无回滚 `probe` 即终态（省一次门禁扫描）。
+2. **只修真正的引号转义 bug（须成对外引号）**：`_requote_block` 仅重写**首尾成对引号**的失败值
+   （`"…"` / `'…'`）——剥一层外引号后单引号重包（内部 `'` 翻倍）。首字符是引号但**首尾不成对**
+   （`"a` 未闭合、`"a"b" # 注释` 带尾注）不是干净引号 bug，强行重包会把尾注/残文吞进值或退化恢复，
+   **留给自愈**；结构性坏值（未闭合 `[a, b`、含冒号串）也不动。已合法的值（`_value_parses` 为真）
+   一律不碰——守住「合法行逐字节不变」。与门禁重判回滚双保险。
+3. **作用面只取本次新引入的 unparsable 页**：违规集来自门禁结论（已是「本次新引入的阻断性」违规），
+   baseline 里早就坏的页不动；缺键/坏类型/缺块等**非引号**问题（`fatal.kind != frontmatter.unparsable`）
+   不在此修。
+4. **正文与 `---` 分隔行逐字节不变**：用 `read_bytes`/`write_bytes` 做 I/O，**避开 `read_text` 的通用
+   换行翻译**（否则 CRLF 页会被静默改成 LF、连带改动正文与分隔行）；只替换 frontmatter 块段、只重写
+   解析失败的标量值行；合法/缩进/列表/注释行原样保留（含原始行尾 CRLF）。
+5. **不跟随符号链接、不写出 `wiki/` 之外**：`write_bytes` 会跟随符号链接，而 `run_check`/`iter_pages`
+   经 `is_file()` 会把指向库外的 `wiki/` 符号链接页纳入校验——若不挡，宿主代码可改动 KB 之外的文件。
+   故**页本身是符号链接、或 `path.resolve()` 逃出 `wiki.resolve()`（父目录符号链接）一律跳过**、交自愈。
+6. **仅 page_guard 路径**：ingest / `query --backfill` / audit 启用；heal（`page_guard=False`）跳过，
+   保其「逐字节不变 + 越界写审计」契约。
+7. **stderr 透明**：修了打印 `✓ 确定性修正 N 页 frontmatter 引号（免去自愈轮）`，不静默改内容；
+   该行属编排核心、走 stderr，不污染 `--json` stdout。
+
+## 3. 不变量
+
+- **零 LLM、零新依赖**（`yaml` 已在依赖内）、**无新命令 / 无新退出码 / 无新 SSE**。
+- **门禁结论不变**：修复只是在自愈前多消一类违规；修不掉的一切照旧由有界自愈处理。
+- 测试：`tests/test_fmrepair.py`（引号修复 / 成对外引号才修 / 结构性坏值不碰 / 任何可解析 mapping
+  即落盘并返回原字节 / 拒符号链接页 + 符号链接父目录越界 / CRLF 逐字节 / 非 UTF-8 不崩 / 作用面按
+  kind 过滤、返回 `{页:原字节}`）+ `tests/test_gate.py`（坏引号页**零自愈轮**通过、非引号违规仍照常
+  2 轮自愈、合法页零触碰、heal 路 `page_guard=False` 不修复、**门禁重判回滚源不回退 `sources.dropped`
+  与跨页 alias 撞名**——含 `run_check` 看不见的 page_guard 专属校验）。

--- a/guanlan/fmrepair.py
+++ b/guanlan/fmrepair.py
@@ -1,0 +1,147 @@
+"""确定性 frontmatter 引号修复（消除最常见的写门禁自愈轮）。**零 LLM。**
+
+写门禁每发现一条本次新引入的阻断性违规，就把它回喂同一 Agent 自愈，**每轮 = 一整个
+额外的 Agentao 子进程**（冷启动 + LLM 推理，见 `gate.run_guarded_write_result`）。触发自愈
+的违规里绝大多数是 `frontmatter.unparsable`——字符串值（尤其 `title`）把引号写坏（双引号
+套双引号 / 字符串没用单引号）导致整块 YAML 解析失败。这一类**确定性可修**：坏的只是引号
+转义，意图基本可恢复（剥一层外引号 → 改用单引号重包、内部 `'` 翻倍）。
+
+本模块在 enforce 后、自愈循环前插一道确定性修复，**用一次廉价的 Python 重判换掉一整轮
+LLM 自愈**。三道安全闸把风险压到「最差等于现状」：
+
+1. **parse-verified**：修完整块必须能用**严格档**重新解析成 mapping，否则整页放弃、原样
+   回落现有 LLM 自愈（修不动的页行为和今天逐字节一致，零回归）。
+2. **只碰 `frontmatter.unparsable` 页**：作用面取自门禁的违规集（已是「本次新引入的阻断性」
+   违规）——baseline 里早就坏的页不动。缺键/坏类型/缺块不在此修（非引号问题）。
+3. **正文与 `---` 分隔行逐字节不变**：只重写解析失败的标量值行。
+
+这是宿主侧专项确定性 frontmatter 操作（仿 `provenance.py` 的 `raw_digest` 盖章），便于单测。
+复用 `pages.py` 的 `split_frontmatter` / `parse_frontmatter` 严格档归口，不另写 YAML 解析。
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import yaml
+
+from .check import Violation
+from .pages import parse_frontmatter, split_frontmatter
+
+__all__ = ["repair_page_frontmatter", "repair_unparsable_pages"]
+
+# 顶层 `key: value` 映射条目行：key 在第 0 列（非缩进续行）、非 `#` 注释、非 `-` 列表项、
+# key 内不含 `:`（约定里键都是 plain 标量）；冒号后须至少一个空白 + 非空值。其余行（缩进/
+# 列表/注释/空行/纯分隔）一律不匹配 → 原样保留。行尾在调用处单独剥离，这里只匹配内容部分。
+_ENTRY_RE = re.compile(r"^([^\s#:-][^:]*):([ \t]+)(\S.*?)[ \t]*$")
+
+
+def _value_parses(value: str) -> bool:
+    """该标量值单独是否已是合法 YAML（合法标量/行内集合 → 不动）。`yaml.YAMLError` 即不合法。
+
+    **必须保留**：先放过已合法的值，才能保证不去重写本就正确的引号行（如另一行坏掉导致整块
+    unparsable 时，合法的 `title: "正常"` 不被无谓改成 `title: '正常'`），守住「合法行逐字节不变」。
+    """
+    try:
+        yaml.safe_load(value)
+    except yaml.YAMLError:
+        return False
+    return True
+
+
+def _requote_block(block: str) -> str | None:
+    """按行把解析失败的顶层标量值改用单引号重包。无任何行被改 → 返回 None。
+
+    保留每行原始行尾（`splitlines(keepends=True)`，CRLF 亦原样）；已合法的值、缩进/列表/注释行
+    一律不碰。**只修真正的引号转义 bug**：值须有**成对外引号**（首尾同为 `"` 或 `'`）——剥一层外引号
+    后用单引号重包（内部 `'` 翻倍）。首字符是引号但首尾不成对（`"a` 未闭合、`"a"b" # 注释` 带尾注）
+    不是干净引号 bug，强行重包会把尾注/残文吞进值或产生退化恢复，**一律留给 LLM 自愈**。
+    """
+    changed = False
+    out: list[str] = []
+    for raw_line in block.splitlines(keepends=True):
+        stripped = raw_line.rstrip("\r\n")
+        eol = raw_line[len(stripped):]
+        m = _ENTRY_RE.match(stripped)
+        if m is None:
+            out.append(raw_line)
+            continue
+        key, sep, value = m.group(1), m.group(2), m.group(3)
+        if _value_parses(value):
+            out.append(raw_line)
+            continue
+        if not (len(value) >= 2 and value[0] == value[-1] and value[0] in "\"'"):
+            out.append(raw_line)  # 无成对外引号 → 非干净引号 bug，留给自愈
+            continue
+        recovered = value[1:-1]  # 剥成对外引号（已确认成对）
+        new_value = "'" + recovered.replace("'", "''") + "'"
+        out.append(f"{key}:{sep}{new_value}{eol}")
+        changed = True
+    return "".join(out) if changed else None
+
+
+def repair_page_frontmatter(path: Path, wiki: Path) -> bytes | None:
+    """尝试修一张 frontmatter 引号写坏的页面：写了返回**原字节**（供门禁回滚），否则返回 None。
+
+    本函数只负责确定性的「把成对外引号的失败标量值单引号重包、整块复验为 mapping 后落盘」这一步——
+    **不判定该页是否真的全清**。「修完是否真省下一轮自愈」由调用方门禁用**真 `enforce_write_result`
+    重判 + 回滚未清页**裁定（见 `gate.run_guarded_write_result`）：验收判据**就是门禁本身**，故决不会
+    漏掉门禁里任何一道校验——`run_check`（frontmatter/断链/sources/alias）**以及** page_guard 专属的
+    `_check_source_regression`（`sources.dropped` 源不回退，`run_check` 看不见）都在门禁重判里兜住。
+    `wiki` 仅用于 `wiki.parent`（库根）锚定与符号链接越界判定。
+
+    - 仅当严格档解析失败为 `frontmatter.unparsable` 才尝试（缺键/坏类型/缺块等非引号问题不在此修）。
+    - **拒符号链接 / 越界路径**：`write_bytes` 跟随符号链接，而 `iter_pages` 经 `is_file()` 会把指向库外的
+      `wiki/` 符号链接页纳入校验——若不挡，宿主代码会改动 KB 之外的文件。故页本身是符号链接、或解析后逃出
+      `wiki/`（父目录符号链接）一律跳过、返回 None。
+    - **逐字节 I/O**：`read_bytes`/`write_bytes` 避开 `read_text` 换行翻译（否则 CRLF 被静默改成 LF、连带
+      改动正文与 `---` 分隔行）；只替换 frontmatter 块段，原 `---` 行与 body 逐字节不变。
+    """
+    # 安全闸：符号链接页 / 解析后逃出 wiki/ 的路径不修（修复是可选优化，越界即跳过、最差=现状）。
+    if path.is_symlink():
+        return None
+    try:
+        if not path.resolve().is_relative_to(wiki.resolve()):
+            return None
+    except OSError:
+        return None
+    original = path.read_bytes()
+    text = original.decode("utf-8")
+    block, _body = split_frontmatter(text)
+    if block is None:
+        return None
+    _meta, fatal = parse_frontmatter(block)
+    if fatal is None or fatal.kind != "frontmatter.unparsable":
+        return None
+    new_block = _requote_block(block)
+    if new_block is None:
+        return None
+    new_meta, new_fatal = parse_frontmatter(new_block)
+    if new_fatal is not None or not isinstance(new_meta, dict):
+        return None  # 仍解析不通 / 非映射 → 放弃，交 LLM 自愈
+    # 仅替换 block 段：保留原首/尾 `---` 行与 body 逐字节（split_frontmatter 已确认两者存在）。
+    lines = text.splitlines(keepends=True)
+    close = next(i for i in range(1, len(lines)) if lines[i].strip() == "---")
+    new_text = lines[0] + new_block + lines[close] + "".join(lines[close + 1:])
+    path.write_bytes(new_text.encode("utf-8"))
+    return original
+
+
+def repair_unparsable_pages(root: Path, violations: list[Violation]) -> dict[str, bytes]:
+    """对违规集里 `frontmatter.unparsable` 的页逐页确定性修引号、落盘，返回 `{相对库根 posix: 原字节}`。
+
+    `violations` 取自门禁结论（已是本次新引入的阻断性违规集）。返回的原字节供门禁**重判后回滚仍阻断
+    的修复页**——「最差 = 现状」由门禁回滚兜底，本函数不自行判定全清（见 `repair_page_frontmatter`）。
+    单页 IO / 解码失败吞掉、交后续自愈，不连累其余页。键去重排序，确定可重放。
+    """
+    wiki = Path(root) / "wiki"
+    out: dict[str, bytes] = {}
+    for rel in sorted({v.page for v in violations if v.kind == "frontmatter.unparsable"}):
+        try:
+            original = repair_page_frontmatter(Path(root) / rel, wiki)
+        except (OSError, UnicodeDecodeError):  # 非 UTF-8 页解码失败也吞掉（UnicodeDecodeError 非 OSError）
+            original = None
+        if original is not None:
+            out[rel] = original
+    return out

--- a/guanlan/gate.py
+++ b/guanlan/gate.py
@@ -27,6 +27,7 @@ from .errors import (
     EXIT_OK,
     EXIT_RAW_MUTATED,
 )
+from .fmrepair import repair_unparsable_pages
 from .pages import iter_pages, load_page
 from .runtime import AgentRunner, AgentRunResult, run_agent_task
 
@@ -424,9 +425,14 @@ def run_guarded_write_result(
 ) -> GuardedWriteResult:
     """写入口的统一编排核心，**不向 stdout 打印门禁报告**（决策P3.2-13）。
 
-    快照 `raw/` → Agentao(`workspace-write`) → `enforce_write_result` → 有界自愈 → 结构化结果。
-    门禁、自愈、退出码全在此收口；是否打印交给调用方（`run_guarded_write` 薄壳打印，heal 自渲染）。
-    自愈进度行 `↻ …` 仍走 **stderr**（属编排核心、不污染 `--json` 的 stdout）。
+    快照 `raw/` → Agentao(`workspace-write`) → `enforce_write_result` → **确定性 frontmatter 引号修复**
+    （仅 `page_guard` 路径）→ 有界自愈 → 结构化结果。门禁、修复、自愈、退出码全在此收口；是否打印
+    交给调用方（`run_guarded_write` 薄壳打印，heal 自渲染）。进度行 `↻ …`/`✓ 确定性修正 …` 均走
+    **stderr**（属编排核心、不污染 `--json` 的 stdout）。
+
+    **确定性 frontmatter 引号修复（仅 page_guard 路径）**：首轮门禁若因 `frontmatter.unparsable`
+    （字符串值引号写坏）失败，先零-LLM 修引号、重判一次，把这条最高频自愈轮省掉（见 `fmrepair.py`、
+    docs/ingest-frontmatter-自愈消除.md）。page_guard=False 的 heal 跳过（保其逐字节不变契约）。
 
     **增量门禁（决策7/8）**：写操作**前**先取 `raw/` 快照与阻断性违规基线 `baseline`；门禁只追究
     **本次新引入**的阻断性违规（frontmatter/sources），历史断链/欠债不连累本次。断链全程作警告。
@@ -454,6 +460,36 @@ def run_guarded_write_result(
     gate = enforce_write_result(
         root, before, first_result, page_before=page_before, baseline=baseline
     )
+
+    # 确定性 frontmatter 引号修复：写门禁最高频的自愈触发器是 `frontmatter.unparsable`
+    # （字符串值引号写坏），这一类零-LLM 可修。先确定性修引号落盘，再用**真门禁重判**裁定——
+    # 验收判据就是 `enforce_write_result` 本身（含 run_check + 源不回退 + raw 完整性），故决不会漏掉
+    # 任何门禁校验；仍有新阻断违规的修复页**一律回滚**（只接受真省下自愈轮的修复，决不留半成品写），
+    # 修不动/回滚的残留照样进下面的有界自愈（零回退）。**仅 page_guard 路径**（ingest/backfill/audit）
+    # 启用：page_guard=False 的 heal 直调本核心、契约是「逐字节不变 + 越界写审计」，跳过修复保其行为不变。
+    if page_guard and gate.kind == "check_failed":
+        written = repair_unparsable_pages(root, gate.violations)
+        if written:
+            probe = enforce_write_result(
+                root, before, first_result, page_before=page_before, baseline=baseline
+            )
+            stuck = {rel for rel in written if any(v.page == rel for v in probe.violations)}
+            for rel in stuck:
+                (Path(root) / rel).write_bytes(written[rel])  # 仍阻断 → 回滚到原字节，最差=现状
+            kept = [rel for rel in sorted(written) if rel not in stuck]
+            if kept:
+                print(
+                    f"✓ 确定性修正 {len(kept)} 页 frontmatter 引号（免去自愈轮）",
+                    file=sys.stderr,
+                )
+            # probe 反映回滚前状态；有回滚须重判得终态，无回滚 probe 即终态（省一次门禁扫描）。
+            gate = (
+                enforce_write_result(
+                    root, before, first_result, page_before=page_before, baseline=baseline
+                )
+                if stuck
+                else probe
+            )
 
     attempt = 0
     while gate.kind == "check_failed" and attempt < max_repair:

--- a/tests/test_fmrepair.py
+++ b/tests/test_fmrepair.py
@@ -1,0 +1,242 @@
+"""确定性 frontmatter 引号修复测试（零 LLM，见 guanlan/fmrepair.py）。
+
+核心安全契约：修完整块必须严格档解析为 mapping，否则不写盘（最差 = 现状）；只碰引号写坏、
+不 mangle 结构性坏值；正文与 `---` 分隔行逐字节不变。
+"""
+
+from pathlib import Path
+
+from guanlan.check import Violation
+from guanlan.fmrepair import (
+    _requote_block,
+    _value_parses,
+    repair_page_frontmatter,
+    repair_unparsable_pages,
+)
+from guanlan.pages import parse_frontmatter, split_frontmatter
+
+# 完整页面模板：{fm} 是 frontmatter 块内文（不含 --- 分隔行），{body} 是正文。
+PAGE = "---\n{fm}---\n\n{body}\n"
+# 除 title 外的必备键（全清验收要求页面 frontmatter 完全合规才写盘，故成功修复用例须备齐）。
+TAIL = "type: concept\ntags: []\nsources: []\nlast_updated: 2026-06-03\n"
+
+
+def _write(tmp_path: Path, rel: str, fm: str, body: str = "正文") -> Path:
+    p = tmp_path / rel
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(PAGE.format(fm=fm, body=body), encoding="utf-8")
+    return p
+
+
+# --- _value_parses ---
+
+
+def test_value_parses_distinguishes_legal_from_broken():
+    assert _value_parses("T") and _value_parses("[]") and _value_parses("[a, b]")
+    assert _value_parses("2026-06-03")
+    assert not _value_parses('"他说"你好""')  # 双引号套双引号
+    assert not _value_parses("'it's broken'")  # 坏单引号
+
+
+# --- _requote_block：作用面与安全边界 ---
+
+
+def test_requote_double_quote_nesting():
+    """双引号套双引号 → 单引号重包，恢复出原意字符串。"""
+    block = 'title: "他说"你好""\ntype: concept\n'
+    new = _requote_block(block)
+    meta, fatal = parse_frontmatter(new)
+    assert fatal is None
+    assert meta["title"] == '他说"你好"'
+    assert meta["type"] == "concept"  # 合法行不动
+
+
+def test_requote_broken_single_quote():
+    new = _requote_block("name: 'it's broken'\n")
+    meta, fatal = parse_frontmatter(new)
+    assert fatal is None and meta["name"] == "it's broken"
+
+
+def test_requote_legal_block_returns_none():
+    """全合法块 → None（一字不改）。"""
+    assert _requote_block("title: T\ntype: concept\ntags: []\nsources: []\n") is None
+
+
+def test_requote_leaves_structural_breakage_to_selfheal():
+    """结构性坏值（不以引号开头）一律不动——避免把列表/含冒号串 mangle 成字符串。"""
+    assert _requote_block("title: T\ntags: [a, b\n") is None  # 未闭合行内列表
+    assert _requote_block("title: C: The Language\n") is None  # 未加引号含冒号（值单独可解析为 dict）
+
+
+def test_requote_requires_matched_quote_pair():
+    """首尾不成对的引号坏值（未闭合 / 带尾注）一律不动——避免吞尾注或退化恢复。"""
+    assert _requote_block('title: "a\n') is None  # 未闭合
+    assert _requote_block('title: "a"b" # 注释\n') is None  # 首 " 尾非 " → 不成对，会把 ` # 注释` 吞进值
+    assert _requote_block("title: 'a\n") is None  # 单引号未闭合
+
+
+def test_requote_ignores_indented_and_list_lines():
+    """缩进续行 / 列表项 / 注释行不被误改，只动顶层标量值。"""
+    block = 'title: "a"b"\n# 注释\nmeta:\n  - x\n  - y\n'
+    new = _requote_block(block)
+    assert new is not None
+    assert "title: 'a\"b'" in new
+    assert "# 注释\n" in new and "  - x\n" in new and "  - y\n" in new  # 原样
+
+
+def test_requote_multiple_bad_fields():
+    block = 'title: "a"b"\norigin: "x"y"\ntype: concept\n'
+    meta, fatal = parse_frontmatter(_requote_block(block))
+    assert fatal is None
+    assert meta["title"] == 'a"b' and meta["origin"] == 'x"y'
+
+
+def test_requote_preserves_crlf_line_endings():
+    """保留每行原始行尾（含 CRLF）。"""
+    new = _requote_block('title: "a"b"\r\ntype: concept\r\n')
+    assert new is not None and new.endswith("\r\n")
+    assert "title: 'a\"b'\r\n" in new
+
+
+# --- repair_page_frontmatter：requote + 落盘，返回原字节 | None（全清裁定归门禁） ---
+# 注：本函数**不判定该页是否全清**——它只确保「重写后能解析为 mapping」即落盘并返回原字节；
+# 「修完是否真省下自愈轮（类型/跨页 alias/源不回退）」由门禁重判 + 回滚裁定，见 tests/test_gate.py。
+
+
+def test_repair_page_fixes_quote_and_preserves_body(tmp_path: Path):
+    body = "## 标题\n\n[[Foo]] 正文行\n含 --- 分隔样式与 `code`\n"
+    p = _write(tmp_path, "wiki/concepts/Foo.md", 'title: "他说"你好""\n' + TAIL, body)
+    _block_before, body_before = split_frontmatter(p.read_text(encoding="utf-8"))
+    assert repair_page_frontmatter(p, tmp_path / "wiki") is not None  # 写了（返回原字节供门禁回滚）
+    block_after, body_after = split_frontmatter(p.read_text(encoding="utf-8"))
+    parsed, fatal = parse_frontmatter(block_after)
+    assert fatal is None and parsed["title"] == '他说"你好"'
+    assert body_after == body_before  # 正文逐字节不变（含 `---` 分隔样式行）
+
+
+def test_repair_page_returns_original_bytes_for_rollback(tmp_path: Path):
+    """落盘成功 → 返回**写前原字节**（供门禁回滚），且已确实改盘；该页全清与否由门禁裁定。"""
+    p = _write(tmp_path, "wiki/concepts/Foo.md", 'title: "a"b"\n' + TAIL)
+    before = p.read_bytes()
+    original = repair_page_frontmatter(p, tmp_path / "wiki")
+    assert original == before  # 返回的是写前原字节
+    assert p.read_bytes() != before  # 已落盘修复
+
+
+def test_repair_page_writes_any_parse_valid_requote(tmp_path: Path):
+    """只要「重写后能解析为 mapping」即落盘——纵使 tags 被重包成字符串（bad_type）也写、留门禁回滚。"""
+    p = _write(tmp_path, "wiki/concepts/T.md", 'title: T\ntags: "a"b"\ntype: concept\nsources: []\nlast_updated: 2026-06-03\n')
+    before = p.read_bytes()
+    assert repair_page_frontmatter(p, tmp_path / "wiki") == before
+    meta, fatal = parse_frontmatter(split_frontmatter(p.read_text(encoding="utf-8"))[0])
+    assert fatal is None and meta["tags"] == 'a"b'  # 已成合法 mapping（tags 是字符串，全清判给门禁）
+
+
+def test_repair_page_rejects_symlink_page(tmp_path: Path):
+    """符号链接页一律不修——否则 write_bytes 跟随符号链接改动 KB 之外的文件（回归 Codex P2）。"""
+    outside = tmp_path / "outside.md"
+    outside.write_text(PAGE.format(fm='title: "他说"你好""\n' + TAIL, body="库外内容"), encoding="utf-8")
+    before = outside.read_bytes()
+    link = tmp_path / "wiki" / "concepts" / "link.md"
+    link.parent.mkdir(parents=True)
+    link.symlink_to(outside)  # wiki 页是指向库外文件的符号链接
+    assert repair_page_frontmatter(link, tmp_path / "wiki") is None
+    assert outside.read_bytes() == before  # 库外文件一字未动
+
+
+def test_repair_page_rejects_symlinked_parent_escape(tmp_path: Path):
+    """页本身非符号链接、但父目录是指向库外的符号链接 → 解析越界、不修（覆盖 resolve 闸）。"""
+    outside_dir = tmp_path / "outside"
+    outside_dir.mkdir()
+    target = outside_dir / "Foo.md"
+    target.write_text(PAGE.format(fm='title: "a"b"\n' + TAIL, body="x"), encoding="utf-8")
+    before = target.read_bytes()
+    wiki = tmp_path / "wiki"
+    wiki.mkdir()
+    (wiki / "concepts").symlink_to(outside_dir, target_is_directory=True)
+    page = wiki / "concepts" / "Foo.md"  # Foo.md 自身非符号链接，但经符号链接父目录解析到库外
+    assert page.is_symlink() is False
+    assert repair_page_frontmatter(page, wiki) is None
+    assert target.read_bytes() == before
+
+
+def test_repair_page_preserves_crlf_bytes(tmp_path: Path):
+    """CRLF 页：逐字节 I/O 不把 \\r\\n 翻成 \\n——正文/分隔行字节不变，只 title 行被修。"""
+    p = tmp_path / "wiki" / "concepts" / "C.md"
+    p.parent.mkdir(parents=True)
+    raw = (
+        '---\r\ntitle: "a"b"\r\ntype: concept\r\ntags: []\r\nsources: []\r\n'
+        "last_updated: 2026-06-03\r\n---\r\n\r\nbody 行\r\n"
+    )
+    p.write_bytes(raw.encode("utf-8"))
+    assert repair_page_frontmatter(p, tmp_path / "wiki") is not None
+    out = p.read_bytes()
+    assert b"title: 'a\"b'\r\n" in out  # title 修好、仍 CRLF
+    assert b"\r\nbody \xe8\xa1\x8c\r\n" in out  # 正文 CRLF 逐字节保留
+    assert b"\n\n" not in out.replace(b"\r\n", b"")  # 无被翻译出的裸 LF
+
+
+def test_repair_page_skips_when_legal(tmp_path: Path):
+    """已合法页 → 不写盘、文件字节不变、返回 None。"""
+    p = _write(tmp_path, "wiki/concepts/Ok.md", "title: T\ntype: concept\ntags: []\nsources: []\n")
+    before = p.read_bytes()
+    assert repair_page_frontmatter(p, tmp_path / "wiki") is None
+    assert p.read_bytes() == before
+
+
+def test_repair_page_bails_on_unfixable(tmp_path: Path):
+    """不可修复（结构性坏值）→ 重写后仍解析失败 → 不写盘、字节不变、返回 None。"""
+    p = _write(tmp_path, "wiki/concepts/Bad.md", "title: T\ntags: [a, b\n")
+    before = p.read_bytes()
+    assert repair_page_frontmatter(p, tmp_path / "wiki") is None
+    assert p.read_bytes() == before
+
+
+def test_repair_page_skips_non_unparsable(tmp_path: Path):
+    """缺键/坏类型等非引号问题不在此修（fatal.kind != frontmatter.unparsable 或无 fatal）。"""
+    # 坏类型但可解析（type=bogus）：parse 无 fatal → 不碰。
+    p = _write(tmp_path, "wiki/concepts/T.md", "title: T\ntype: bogus\ntags: []\nsources: []\n")
+    before = p.read_bytes()
+    assert repair_page_frontmatter(p, tmp_path / "wiki") is None
+    assert p.read_bytes() == before
+
+
+def test_repair_page_no_frontmatter(tmp_path: Path):
+    """无 frontmatter 块 → None。"""
+    p = tmp_path / "wiki" / "x.md"
+    p.parent.mkdir(parents=True)
+    p.write_text("没有 frontmatter 的正文\n", encoding="utf-8")
+    assert repair_page_frontmatter(p, tmp_path / "wiki") is None
+
+
+# --- repair_unparsable_pages：作用面取自违规集，返回 {页: 原字节} ---
+
+
+def test_repair_unparsable_pages_filters_by_kind(tmp_path: Path):
+    """只修 frontmatter.unparsable 违规列出的页；返回 {相对库根 posix: 写前原字节}。"""
+    a_before = _write(tmp_path, "wiki/concepts/A.md", 'title: "x"y""\n' + TAIL).read_bytes()
+    _write(tmp_path, "wiki/concepts/B.md", "title: T\n" + TAIL)
+    violations = [
+        Violation("wiki/concepts/A.md", "frontmatter.unparsable", "…"),
+        Violation("wiki/concepts/B.md", "wikilink.broken", "…"),  # 非本类，不碰
+    ]
+    written = repair_unparsable_pages(tmp_path, violations)
+    assert set(written) == {"wiki/concepts/A.md"}
+    assert written["wiki/concepts/A.md"] == a_before  # 值是写前原字节（供门禁回滚）
+    # A 现已可解析
+    assert parse_frontmatter(split_frontmatter((tmp_path / "wiki/concepts/A.md").read_text())[0])[1] is None
+
+
+def test_repair_unparsable_pages_empty_when_no_unparsable(tmp_path: Path):
+    assert repair_unparsable_pages(tmp_path, [Violation("p", "sources.dropped", "…")]) == {}
+
+
+def test_repair_unparsable_pages_handles_non_utf8(tmp_path: Path):
+    """非 UTF-8 页解码失败被吞掉、不连累其余页、不抛（UnicodeDecodeError 非 OSError）。"""
+    p = tmp_path / "wiki" / "concepts" / "Bad.md"
+    p.parent.mkdir(parents=True)
+    p.write_bytes(b"---\ntitle: \xff\xfe \n---\nbody\n")  # 非法 UTF-8 字节
+    written = repair_unparsable_pages(
+        tmp_path, [Violation("wiki/concepts/Bad.md", "frontmatter.unparsable", "…")]
+    )
+    assert written == {}  # 解码失败 → 跳过、不崩

--- a/tests/test_gate.py
+++ b/tests/test_gate.py
@@ -673,6 +673,155 @@ def test_guarded_write_raw_priority_over_regression(tmp_path: Path):
     assert result.exit_code == EXIT_RAW_MUTATED
 
 
+# ====================================================================
+# 确定性 frontmatter 引号修复：消除最常见的自愈轮（见 guanlan/fmrepair.py）。
+# 坏引号页本可解析失败 → 触发一整轮 LLM 自愈；宿主确定性修引号后零自愈直接过。
+# ====================================================================
+
+
+def _write_quote_broken(root: Path, name: str = "Q") -> None:
+    """写一页 frontmatter 引号写坏（title 双引号套双引号）的实体页——除此外全合法。"""
+    p = root / "wiki" / "entities" / f"{name}.md"
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(
+        '---\ntitle: "他说"你好""\ntype: entity\ntags: []\nsources: []\n'
+        "last_updated: 2026-06-03\n---\n\n正文\n",
+        encoding="utf-8",
+    )
+
+
+def _runner_quote_broken():
+    """每次被调都写同一页坏引号 frontmatter（若有自愈轮会再写一次→可观测）。"""
+    state = {"n": 0}
+
+    def runner(prompt, **kwargs):
+        state["n"] += 1
+        _write_quote_broken(kwargs["working_directory"])
+        return AgentRunResult(ok=True, final_text="done")
+
+    runner.state = state
+    return runner
+
+
+def test_frontmatter_quote_repair_skips_selfheal(tmp_path: Path, capsys):
+    """坏引号 frontmatter → 宿主确定性修 → 门禁通过，**自愈轮数为 0**（runner 只被调一次）。"""
+    _kb_writable(tmp_path)
+    runner = _runner_quote_broken()
+    result = run_guarded_write_result(tmp_path, "PROMPT", runner=runner, page_guard=True)
+    assert result.exit_code == EXIT_OK
+    assert result.gate.ok
+    assert runner.state["n"] == 1  # 关键：无 REPAIR_PROMPT 自愈轮
+    err = capsys.readouterr().err
+    assert "确定性修正" in err and "门禁未过" not in err  # 修了、且未进自愈
+
+
+def test_frontmatter_quote_repair_actually_fixes_disk(tmp_path: Path):
+    """修复是真写盘：通过后该页 frontmatter 严格档可解析、title 还原。"""
+    _kb_writable(tmp_path)
+    run_guarded_write_result(
+        tmp_path, "PROMPT", runner=_runner_quote_broken(), page_guard=True
+    )
+    from guanlan.pages import parse_frontmatter, split_frontmatter
+
+    text = (tmp_path / "wiki" / "entities" / "Q.md").read_text(encoding="utf-8")
+    meta, fatal = parse_frontmatter(split_frontmatter(text)[0])
+    assert fatal is None and meta["title"] == '他说"你好"'
+
+
+def test_frontmatter_repair_leaves_non_quote_violations_to_selfheal(tmp_path: Path, capsys):
+    """非引号类阻断违规（bad_type）不被修复触碰 → 仍走完整有界自愈、行为与今相同。"""
+    _kb_writable(tmp_path)
+    state = {"n": 0}
+
+    def runner(prompt, **kwargs):
+        state["n"] += 1
+        _bad_fm_page(kwargs["working_directory"])  # type=bogus，可解析但 bad_type
+        return AgentRunResult(ok=True, final_text="done")
+
+    result = run_guarded_write_result(tmp_path, "PROMPT", runner=runner, page_guard=True)
+    assert result.exit_code == EXIT_CHECK_FAILED
+    assert any(v.kind == "frontmatter.bad_type" for v in result.gate.violations)
+    assert state["n"] == 3  # 首轮 + 2 自愈，未被修复短路
+    assert "确定性修正" not in capsys.readouterr().err
+
+
+def test_frontmatter_repair_untouched_when_clean(tmp_path: Path, capsys):
+    """合法页过门禁 → 修复零触碰、stderr 无修正行。"""
+    _kb_writable(tmp_path)
+    result = run_guarded_write_result(
+        tmp_path, "PROMPT", runner=make_runner(_good_page), page_guard=True
+    )
+    assert result.exit_code == EXIT_OK
+    assert "确定性修正" not in capsys.readouterr().err
+
+
+def test_frontmatter_repair_reverts_source_regression(tmp_path: Path, capsys):
+    """修复页若仍含 page_guard 源不回退（sources.dropped，`run_check` 看不见）→ 门禁回滚修复（回归 Codex P2）。
+
+    既有页 X（sources {a,b}）被 agent 写成「坏引号 + 丢源 b」：unparsable 掩盖了 sources.dropped；
+    修引号后 dropped 浮现 → 门禁重判（含 `_check_source_regression`）判 X 仍阻断 → **回滚**到 agent 原写。
+    无回滚（旧 `run_check`-only 验收）会保留 `title: 'a"b'` 半成品并打印「确定性修正」——这里反证已回滚。
+    """
+    _kb(tmp_path)
+    _src(tmp_path, "a")
+    _src(tmp_path, "b")
+    _entity(tmp_path, "X", "[a, b]")  # 既有页 X，sources {a,b} 进 page_before
+
+    def runner(prompt, **kwargs):
+        (kwargs["working_directory"] / "wiki" / "entities" / "X.md").write_text(
+            '---\ntitle: "a"b"\ntype: entity\ntags: []\nsources: [a]\n'
+            "last_updated: 2026-06-03\n---\n\n正文\n",
+            encoding="utf-8",
+        )
+        return AgentRunResult(ok=True, final_text="done")
+
+    result = run_guarded_write_result(
+        tmp_path, "P", runner=runner, page_guard=True, max_repair=0
+    )
+    assert result.exit_code == EXIT_CHECK_FAILED
+    x = (tmp_path / "wiki" / "entities" / "X.md").read_text(encoding="utf-8")
+    assert 'title: "a"b"' in x  # 回滚到 agent 原写（坏引号），非保留修复后的 'a"b'
+    assert "确定性修正" not in capsys.readouterr().err  # kept 为空 → 不打印
+
+
+def test_frontmatter_repair_reverts_hidden_alias_collision(tmp_path: Path, capsys):
+    """unparsable 掩盖的跨页 alias 撞名，修引号后浮现 → 门禁回滚（`run_check` 侧，回归 Codex P2）。"""
+    _kb(tmp_path)
+    foo = tmp_path / "wiki" / "concepts" / "Foo.md"  # 既有页 stem foo
+    foo.parent.mkdir(parents=True)
+    foo.write_text(FM.format(type="concept", sources="[]", body="正文"), encoding="utf-8")
+
+    def runner(prompt, **kwargs):
+        (kwargs["working_directory"] / "wiki" / "concepts" / "Bar.md").write_text(
+            '---\ntitle: "a"b"\ntype: concept\ntags: []\nsources: []\n'
+            "last_updated: 2026-06-03\naliases: ['Foo']\n---\n\n正文\n",
+            encoding="utf-8",
+        )
+        return AgentRunResult(ok=True, final_text="done")
+
+    result = run_guarded_write_result(
+        tmp_path, "P", runner=runner, page_guard=True, max_repair=0
+    )
+    assert result.exit_code == EXIT_CHECK_FAILED
+    bar = (tmp_path / "wiki" / "concepts" / "Bar.md").read_text(encoding="utf-8")
+    assert 'title: "a"b"' in bar  # 回滚（修复后会是 'a"b' 且撞名 Foo）
+    assert "确定性修正" not in capsys.readouterr().err
+
+
+def test_frontmatter_repair_skipped_on_heal_path(tmp_path: Path, capsys):
+    """page_guard=False（heal 直调本核心）→ 修复不启用，保 heal 逐字节不变契约。
+
+    坏引号页本可被宿主修好；但 heal 路不该被改页，故仍走自愈（runner 持续重写坏页 → 修不掉）
+    → EXIT_CHECK_FAILED、stderr 无「确定性修正」。
+    """
+    _kb_writable(tmp_path)
+    runner = _runner_quote_broken()
+    result = run_guarded_write_result(tmp_path, "PROMPT", runner=runner, page_guard=False)
+    assert result.exit_code == EXIT_CHECK_FAILED
+    assert any(v.kind == "frontmatter.unparsable" for v in result.gate.violations)
+    assert "确定性修正" not in capsys.readouterr().err
+
+
 # --- report_outcome：骤缩警告独立成行（与断链并列、区分 kind）---
 
 


### PR DESCRIPTION
把搁置在本地分支 `feat/ingest-frontmatter-quote-repair` 的特性**摘核心实现、rebase 到当前 main 后**重新落地（cherry-pick 自 `b330c98`）。原分支因 fork 早于 `8c4adce`、其 `test_web.py` 仍带真实 KB 名（`标准体系-20240531` 等），**不可整支合并**；本 PR 只取干净的核心提交（fmrepair + gate + 自带的中性占位测试 + 设计文档），不含那些真实名。

## 特性
写门禁最高频的自愈触发器是 `frontmatter.unparsable`（字符串值尤其 `title` 引号写坏）。每轮自愈 = 一整个额外 Agentao 子进程（冷启动 + LLM）。本特性零-LLM 确定性修引号、用**真门禁重判**裁定，省掉这条最高频自愈轮。

- `guanlan/fmrepair.py`（新）：剥成对外引号→单引号重包→整块复验为 mapping→逐字节落盘，返回写前原字节
- `guanlan/gate.py`：接入 `run_guarded_write_result`，**仅 page_guard 路径**（ingest/backfill/audit），heal 跳过守逐字节不变契约；修后仍阻断的页一律回滚
- 安全闸：拒符号链接/父目录越界、逐字节 I/O（不改 CRLF）、只修首尾成对引号、非 UTF-8 交自愈

## 验证
- ruff 干净；`tests/test_fmrepair.py` + `tests/test_gate.py` 77 passed；全量 **976 passed**
- 新增文件零真实 KB 名（已 grep `标准体系/数据获取/数据检验/真日期`）
- 无新命令 / 无新退出码 / 无新依赖
- CHANGELOG 已记入 `[Unreleased] 新增`

🤖 Generated with [Claude Code](https://claude.com/claude-code)