### PR TITLE
chore: 测试夹具去残留真实 KB 名（数据检验 → 示例检验）

### DIFF
--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -5166,31 +5166,31 @@ def test_parsed_preview_rewrites_image_to_endpoint(client, kb) -> None:
 # ── 拆分断链恢复（按 basename 从源文件图目录唯一恢复，决策P4.6.1-5）─────────────────────
 def test_image_lint_recovers_split_basename(client, kb) -> None:
     """拆分子文件引用「目录错、basename 对」→ lint 判可重整（非悬空），因源图在原文件图目录唯一可寻。"""
-    _put_parsed_image(kb, "4.数据检验-20240531", "4.数据检验-20240531-7.jpg", b"FIG")
+    _put_parsed_image(kb, "4.示例检验-20240531", "4.示例检验-20240531-7.jpg", b"FIG")
     _put_workspace(
-        kb, "parsed", "4b.数据检验.md",
-        "正文\n![](images/4b.数据检验/4.数据检验-20240531-7.jpg)\n",  # 目录错、basename 对
+        kb, "parsed", "4b.示例检验.md",
+        "正文\n![](images/4b.示例检验/4.示例检验-20240531-7.jpg)\n",  # 目录错、basename 对
     )
     data = client.get(
-        "/api/workspace/image-lint", params={"file": "workspace/parsed/4b.数据检验.md"}
+        "/api/workspace/image-lint", params={"file": "workspace/parsed/4b.示例检验.md"}
     ).json()
     assert data["dangling"] == []  # 不再误判悬空（源图可按 basename 唯一恢复）
-    assert data["misplaced"] == ["images/4b.数据检验/4.数据检验-20240531-7.jpg"]
+    assert data["misplaced"] == ["images/4b.示例检验/4.示例检验-20240531-7.jpg"]
     assert data["needs_relocalize"] is True
 
 
 def test_relocalize_recovers_split_image(client, kb) -> None:
     """重整：把拆分子文件引用的源图（basename 唯一）copy 到本文件目录、改名编号、重写引用（用户诉求）。"""
-    _put_parsed_image(kb, "4.数据检验-20240531", "4.数据检验-20240531-7.jpg", b"FIG")
+    _put_parsed_image(kb, "4.示例检验-20240531", "4.示例检验-20240531-7.jpg", b"FIG")
     _put_workspace(
-        kb, "parsed", "4b.数据检验.md",
-        "正文\n![图](images/4b.数据检验/4.数据检验-20240531-7.jpg)\n",
+        kb, "parsed", "4b.示例检验.md",
+        "正文\n![图](images/4b.示例检验/4.示例检验-20240531-7.jpg)\n",
     )
-    r = client.post("/api/workspace/relocalize", json={"file": "workspace/parsed/4b.数据检验.md"})
+    r = client.post("/api/workspace/relocalize", json={"file": "workspace/parsed/4b.示例检验.md"})
     assert r.status_code == 200
     d = kb / "workspace" / "parsed"
-    assert (d / "images" / "4b.数据检验" / "4b.数据检验-1.jpg").read_bytes() == b"FIG"  # 复制到本文件目录
-    assert "images/4b.数据检验/4b.数据检验-1.jpg" in (d / "4b.数据检验.md").read_text("utf-8")  # 链接已更新
+    assert (d / "images" / "4b.示例检验" / "4b.示例检验-1.jpg").read_bytes() == b"FIG"  # 复制到本文件目录
+    assert "images/4b.示例检验/4b.示例检验-1.jpg" in (d / "4b.示例检验.md").read_text("utf-8")  # 链接已更新
 
 
 def test_image_lint_truly_missing_stays_dangling(client, kb) -> None:


### PR DESCRIPTION
`8c4adce`（去真实 KB 文件名）中性化时**漏了** `tests/test_web.py` 图片测试段的 `4.数据检验-20240531` / `4b.数据检验`（共 11 处）——与当时已清掉的 `标准体系`/`数据获取` 是同批真实名。本 PR 补清，统一 `数据检验` → `示例检验`（贴合现有 `示例*` 占位风格），保留 `4.`/`4b.` 序号与「目录错、basename 对」的错配结构，**测试语义不变**。

## 验证
- `数据检验` 残留 0、`示例检验` 11；全树再扫无非中性的真实日期 KB 名
- `tests/test_web.py` 391 passed；ruff 干净

🤖 Generated with [Claude Code](https://claude.com/claude-code)