### PR TITLE
chore: 进入开发态 0.1.13 → 0.1.14.dev0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 本项目所有显著变更记录于此。格式参考 [Keep a Changelog](https://keepachangelog.com/zh-CN/1.1.0/)，
 版本号遵循 [语义化版本](https://semver.org/lang/zh-CN/)。版本号单一来源为 `guanlan/__init__.py`。
 
+## [Unreleased]
+
 ## [0.1.13] - 2026-06-17
 
 ### 新增

--- a/guanlan/__init__.py
+++ b/guanlan/__init__.py
@@ -4,4 +4,4 @@ P1 交付 `guanlan init`（确定性生成最小模板）。ingest / query 等 L
 由 `guanlan-wiki` skill 驱动 Agentao 完成；本包只做编排与确定性门禁。
 """
 
-__version__ = "0.1.13"
+__version__ = "0.1.14.dev0"


### PR DESCRIPTION
v0.1.13 已发布([PyPI](https://pypi.org/project/guanlan-wiki/0.1.13/) + [GitHub Release](https://github.com/jin-bo/guanlan/releases/tag/v0.1.13))。按既有发版后惯例重入开发态:

- `guanlan/__init__.py`:`0.1.13` → `0.1.14.dev0`(版本号单一来源)
- `CHANGELOG.md`:顶部起新的空 `## [Unreleased]` 段,供下个周期累积

无功能改动。

🤖 Generated with [Claude Code](https://claude.com/claude-code)