### PR TITLE
chore: 进入开发态 0.1.14 → 0.1.15.dev0

### DIFF
--- a/guanlan/__init__.py
+++ b/guanlan/__init__.py
@@ -4,4 +4,4 @@ P1 交付 `guanlan init`（确定性生成最小模板）。ingest / query 等 L
 由 `guanlan-wiki` skill 驱动 Agentao 完成；本包只做编排与确定性门禁。
 """
 
-__version__ = "0.1.14"
+__version__ = "0.1.15.dev0"


### PR DESCRIPTION
v0.1.14 已发布（[PyPI](https://pypi.org/project/guanlan-wiki/0.1.14/) + [GitHub Release](https://github.com/jin-bo/guanlan/releases/tag/v0.1.14)）。按仓库惯例（承 #8）回到开发态：

- `guanlan/__init__.py`：`0.1.14` → `0.1.15.dev0`
- CHANGELOG 顶部 `## [Unreleased]` 段已在定版 PR #9 留空，无需再加。

**无功能改动 / 无新依赖。**

🤖 Generated with [Claude Code](https://claude.com/claude-code)