### PR TITLE
fix: P4.15 确认气泡参数折叠精确裁到三行（修底部透出第 4 行）

### DIFF
--- a/guanlan/web/static/app.css
+++ b/guanlan/web/static/app.css
@@ -111,7 +111,9 @@ body {
   word-break: break-all; font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
   font-size: .72rem; line-height: 1.5;
 }
-.msg.note .interaction-cmd.clamped { overflow: hidden; } /* 折叠：max-height 由 JS 按三行高度内联给出 */
+/* 折叠：max-height 由 JS 按「三行+上内边距+边框」内联给出；padding-bottom:0 让裁剪边界（padding box 底）
+   正好落在第三行末，否则底内边距区会透出第 4 行一截。展开时 .clamped 摘除，padding 复原。 */
+.msg.note .interaction-cmd.clamped { overflow: hidden; padding-bottom: 0; }
 /* 折叠钮浮在参数框内右下角；不透明白底遮住其后的命令文字（等宽 pre 里强制回 UI 字体）。 */
 .msg.note .interaction-cmd-toggle {
   position: absolute; right: .35rem; bottom: .3rem; padding: 0 .35rem;

--- a/guanlan/web/static/chat.js
+++ b/guanlan/web/static/chat.js
@@ -937,10 +937,15 @@ function clampCmd(div, pre) {
   const lineH = parseFloat(cs.lineHeight);
   const padTop = parseFloat(cs.paddingTop) || 0;
   const padBot = parseFloat(cs.paddingBottom) || 0;
+  const bTop = parseFloat(cs.borderTopWidth) || 0;
+  const bBot = parseFloat(cs.borderBottomWidth) || 0;
   if (!(lineH > 0)) return; // line-height 解析失败（如祖先 display:none）：放过，显示全文
-  const innerH = pre.scrollHeight - padTop - padBot; // 纯内容高度（去内边距）
+  const innerH = pre.scrollHeight - padTop - padBot; // 纯内容高度（scrollHeight 含内边距、不含边框）
   if (innerH <= lineH * 3 + 1) return; // 不足/恰好三行：无需折叠
-  const three = lineH * 3 + "px"; // content-box：内容区限三行，原内边距照常渲染
+  // 全局 box-sizing:border-box（app.css），max-height 量的是边框盒；且 overflow:hidden 裁在 padding box，
+  // 故必须把 padTop+边框加回、但**不含 padBot**——否则底内边距区会透出第 4 行一截。配合 .clamped{padding-bottom:0}
+  // 让 padding box 底正好落在第三行末尾：三行完整、零透出、底部齐平（见 docs 截图实测 B/D）。
+  const three = lineH * 3 + padTop + bTop + bBot + "px";
   const clamp = () => { pre.classList.add("clamped"); pre.style.maxHeight = three; };
   clamp();
   const toggle = document.createElement("button");


### PR DESCRIPTION
## 这是什么

修 PR #11 引入的折叠 bug：折叠态会透出第 4 行的一截（约 0.4 行），即「多显示了一点」。

## 根因

全局 `* { box-sizing: border-box }` 下，`overflow: hidden` 的裁剪边界在 **padding box**（边框内沿）。原 `max-height = 三行 + 上内边距 + 下内边距 + 上下边框`，使 padding box 底部多出 `.4rem` 的下内边距区——而下内边距区**在裁剪范围内**，于是第 4 行的开头一截会透进这块区域显示出来。

（更早一版相反：`max-height` 不含内边距 → 第 3 行被切掉一截。两个 bug 同源，都是 border-box 下 `max-height` 与裁剪边界的错配。）

## 修法

`max-height = 三行 + 上内边距 + 上下边框`（**不含下内边距**），并加 `.interaction-cmd.clamped { padding-bottom: 0 }`，让 padding box 底正好落在第三行末尾：

- 三行完整显示、第 4 行零透出；
- 第三行无论空行还是有字，底部都不显挤；
- 展开时 `.clamped` 摘除、内边距复原。

## 验证

Playwright 渲染实测对比了 4 种候选（旧 max-height / 丢 padBot / `-webkit-line-clamp` / `::after` 遮条），量化可视行数并截图：

- 旧线上：3.39 行（透出）— 复现 bug；
- `-webkit-line-clamp`：与 `white-space:pre-wrap` 配合有 glitch（省略号落空白行 + 仍透出），淘汰；
- `::after` 遮条：实测未盖住，淘汰；
- **本方案（丢 padBot + padding-bottom:0）：正好 3 行、零透出、底部不挤、展开钮可见** ✅

`node --check chat.js` 通过。纯前端（`chat.js` + `app.css`），服务端 / i18n 契约零改动。

🤖 Generated with [Claude Code](https://claude.com/claude-code)