### PR TITLE
chore(ci): job 超时上限 + actionlint 校验 workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,8 @@ concurrency:
 jobs:
   test:
     runs-on: ubuntu-latest
+    # 默认 job 超时是 6h；卡死的跑（死锁/等网络）别白烧满额度——全套测试 ~1 分钟，15 分钟极宽裕。
+    timeout-minutes: 15
     # requires-python = ">=3.10"：在下限 3.10 到 3.12 全跑，确保最低支持版本不破。
     strategy:
       fail-fast: false
@@ -44,3 +46,16 @@ jobs:
 
       - name: 跑测试
         run: uv run --extra web --extra mcp --python ${{ matrix.python-version }} pytest -q
+
+  # 改 workflow 时校验：YAML 语法 / action input / ${{ }} 表达式，并对 run: 里的内联 shell 跑 shellcheck
+  # （release.yml 那段抽 CHANGELOG 的 awk/bash 由此受检）。单跑一次、不进 Python 矩阵。
+  # 钉到 actionlint v1.7.12 的镜像 digest（SHA 钉版、可复现，非浮动 :latest）；镜像自带 shellcheck。
+  actionlint:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v6
+      - name: actionlint
+        uses: docker://rhysd/actionlint@sha256:b1934ee5f1c509618f2508e6eb47ee0d3520686341fec936f3b79331f9315667
+        with:
+          args: -color

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,7 @@ permissions: {}
 jobs:
   pypi-publish:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     environment:
       name: pypi
       url: https://pypi.org/p/guanlan-wiki
@@ -41,6 +42,7 @@ jobs:
   github-release:
     needs: pypi-publish
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       contents: write # 建 GitHub Release 必需
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,18 @@
   **内联**图标+文字。ask 提问气泡仍走原状态行。smoke `scripts/smoke_p415.py` 三处确认断言随之更新
   (查 `.chosen` 取代查状态行)。新增两条 i18n 键 `interaction.cmdExpand` / `cmdCollapse`(中英平价)。
 
+### 内部
+
+- **CI 卫生:job 超时上限 + actionlint 校验 workflow** —— 纯仓库基建、与里程碑无关、零功能改动:
+  ① 给 `ci.yml` 的 test job 与 `release.yml` 的 pypi-publish / github-release 各加 `timeout-minutes`
+  (15 / 15 / 10),卡死的跑(死锁 / 等网络)十几分钟内被杀、不白烧 GitHub 默认 **6h** job 超时的额度;
+  ② `ci.yml` 新增独立 `actionlint` job(单跑、不进 3×Python 矩阵),用**钉到 v1.7.12 镜像 digest**
+  (`docker://rhysd/actionlint@sha256:b1934ee5…`、SHA 钉版可复现、非浮动 `:latest`)校验 workflow
+  YAML 语法 / action input / `${{ }}` 表达式,并经镜像自带 shellcheck 检 `run:` 内联 shell
+  (`release.yml` 抽 CHANGELOG 的 awk/bash 由此受检)。`concurrency` ci.yml 早已有、不动;release.yml
+  故意不加(不在发布到一半被取消)。落地前以**钉版 actionlint v1.7.12 + shellcheck** 对两 workflow
+  跑过、零 finding。
+
 ## [0.1.14] - 2026-06-17
 
 ### 新增


### PR DESCRIPTION
纯仓库基建，与里程碑无关、零功能改动（不碰 Python，那 1013 个测试不受影响）。来源：`docs/backlog/notes/gbrain-反向评审结论.md` §11.3 CI 卫生快赢。

## 改了什么

- **`timeout-minutes`** —— `ci.yml` 的 test job 与 `release.yml` 的 pypi-publish / github-release 各加上限（15 / 15 / 10）。GitHub 默认 job 超时是 **6h**；卡死的跑（死锁 / 等网络）会白烧满额度，加上限后十几分钟内被杀。全套测试 ~1 分钟，留 15 分钟极宽裕。
- **`actionlint`（新独立 job）** —— `ci.yml` 加一个单跑、不进 3×Python 矩阵的 job，钉到 **actionlint v1.7.12 镜像 digest**（`docker://rhysd/actionlint@sha256:b1934ee5…`，SHA 钉版可复现、非浮动 `:latest`）。校验 workflow YAML 语法 / action input / `${{ }}` 表达式，并经镜像自带 shellcheck 检 `run:` 内联 shell —— `release.yml` 抽 CHANGELOG 的 awk/bash 由此受检。
- **`concurrency`** —— `ci.yml` 早已有、不动；`release.yml` 故意不加（不在发布到一半被取消）。

## 验证

落地前下了**钉版 actionlint v1.7.12 + shellcheck**，对改后的两个 workflow 跑过 → **零 finding、exit 0**。所以这个新 job 上 CI 不会反过来卡现有文件。

CHANGELOG `[Unreleased]` 加「### 内部」一条。

🤖 Generated with [Claude Code](https://claude.com/claude-code)