### PR TITLE
chore: 进入开发态 0.1.15 → 0.1.16.dev0

### DIFF
--- a/guanlan/__init__.py
+++ b/guanlan/__init__.py
@@ -4,4 +4,4 @@ P1 交付 `guanlan init`（确定性生成最小模板）。ingest / query 等 L
 由 `guanlan-wiki` skill 驱动 Agentao 完成；本包只做编排与确定性门禁。
 """
 
-__version__ = "0.1.15"
+__version__ = "0.1.16.dev0"


### PR DESCRIPTION
v0.1.15 已发布（[PyPI](https://pypi.org/project/guanlan-wiki/0.1.15/) + [GitHub Release](https://github.com/jin-bo/guanlan/releases/tag/v0.1.15)）。按惯例回到开发态：版本号置 `.dev0`。

- `guanlan/__init__.py`：`0.1.15` → `0.1.16.dev0`（版本号单一来源）。
- CHANGELOG 顶部 `[Unreleased]` 段已在定版 PR #14 留空、无需再加。

无功能改动。

🤖 Generated with [Claude Code](https://claude.com/claude-code)