### PR TITLE
chore: 进入开发态 0.1.16 → 0.1.17.dev0

### DIFF
--- a/guanlan/__init__.py
+++ b/guanlan/__init__.py
@@ -4,4 +4,4 @@ P1 交付 `guanlan init`（确定性生成最小模板）。ingest / query 等 L
 由 `guanlan-wiki` skill 驱动 Agentao 完成；本包只做编排与确定性门禁。
 """
 
-__version__ = "0.1.16"
+__version__ = "0.1.17.dev0"


### PR DESCRIPTION
v0.1.16 已发布（tag `v0.1.16` 已打 @`2a8a127`，触发 `release.yml` → PyPI + GitHub Release）。按惯例回到开发态：版本号单一来源 `guanlan/__init__.py` 置 `.dev0`。

- `0.1.16` → `0.1.17.dev0`（1 行）。
- CHANGELOG 顶部 `[Unreleased]` 段已在定版 PR (#17) 留空、无需再加。
- 无功能改动。

🤖 Generated with [Claude Code](https://claude.com/claude-code)