### PR TITLE
feat: Web 正文/对话 raw/<slug>.md 引用联成只读 raw 源链

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ agentao.log.*
 /graph/
 /workspace/
 /.trash/
+/kbs/
 
 # Repo-root sample config copied from examples/ (may carry machine paths / private dev settings).
 # Anchored to root so examples/AGENTAO.md and examples/SCHEMA.md stay tracked.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,37 @@
 
 ## [Unreleased]
 
+### 新增
+
+- **Web 正文/对话里的 `raw/<slug>.md` 引用联成只读 raw 源链** —— wiki 单页（`/api/page`）与对话答案
+  渲染时，把指向**现存** `raw/<slug>.md` 的引用联成可点的 `a.rawlink[data-raw]`：点击在**右栏内联**
+  调既有 `/api/raw/file` 只读渲染那篇原始素材（复用单页历史栈，一键「←」回引用它的原页；左栏对话气泡
+  里点亦切右栏，与既有 `[[wikilink]]` 行为一致）。识别**四种写法**（口径由用户敲定）：① 裸路径串
+  `raw/x.md`（plain text 行内）；② 整段恰好是 `raw/x.md` 的行内 code；③ `[[raw/x]]`（wikilink，带/不带
+  `.md`、支持 `|别名`）；④ markdown 链接 `[文字](raw/x.md)`（改写 `<a href>`、保留链接文字/内联格式、容
+  `./` 前缀）。与 `[[wikilink]]` 同纪律——**仅真实存在**的 raw 文件联链，缺失标灰 `span.rawlink.broken`
+  （dashed 下划线区别于 wikilink 的 dotted）。
+  - **纯前端复用既有只读端点**：`render.py` 三处处理器共用 `raw/*.md` 真实文件名集（`wiki.parent/raw`
+    推出、每渲染重扫，同 `_stem_to_path` 纪律）——`_RawPathTreeprocessor`（裸路径串 + markdown 链接 href，
+    **树上处理**故按祖先跳过 `a`/`code`/`pre`）、`_CodePathLinkTreeprocessor` 内 raw 分支、`_resolve_wikilink`
+    内 `raw/` 前缀拦截；右栏新增 `{kind:"raw"}` 视图（banner 标明「原始素材·只读」+ raw/ 路径 +
+    「在新标签打开」逃生口经 `/?raw=` 弹出 SPA，供并排对照源）。后端 `/api/raw/file`·`/api/raw` 零改动
+    （reader 下仍注册）。
+  - **关键正确性**：`raw/x.md` 即便存在同名 wiki 页也联到 raw 源、绝不误链 wiki（raw 分支先于 `link_stem`
+    页解析）；裸路径串改用 treeprocessor（而非 inline）按祖先跳过 `<a>`——根除 `[raw/x.md](url)` 在链接
+    文字里被回灌再联、套出**非法嵌套 `<a>`** 的隐患；`[**强调**](raw/x.md)` 内联格式不丢；外链/绝对路径
+    （`https://…/raw/y.md`、`/raw/x.md`）不动；`cat raw/x.md` 命令 code 与围栏块字面保留；不给 `wiki` 时
+    不联链（保 P4 既有姿态）。新增 4 条 i18n 键 `raw.{banner,openInTab,loading,openFail}`（中英平价）；
+    测试见 `tests/test_web.py`。
+  - **多智能体评审修复**（同一变更内）：`span` 纳入 `_RAW_SKIP_SUBTREE`——杜绝 `[raw/exists.md](raw/missing.md)`
+    在断链灰 span 内再联出**可点且指向另一源**的 rawlink；basename 解析改为「按存在性试 `<名>` 与 `<名>.md`」
+    （`_lookup_raw`）——含内部点的 stem（`raw/1.示例报告`）正确命中，且 markdown 链接指向**非 `.md` 资产**
+    （`raw/report.pdf`、`raw/images/x.png`）时**原样保留 href**、不再毁成断链 span；去掉 wikilink display 的
+    `AtomicString` 包裹——恢复 `[[页|**别名**]]` 别名内联格式渲染（旧实现的既有 wikilink 回归）；裸路径尾界
+    `(?![\w\-])` 放行句末 `.`（`raw/x.md.` 仍联链）；`_raw_name_index` 精确文件名键 + 无冲突小写兜底（镜像
+    `link_resolution_index` fold 纪律）——大小写敏感盘上 `raw/Foo.md`/`raw/foo.md` 各按真实名解析、零串台；
+    markdown 链接改写保留作者 `title`；`_linkify` 尾段插入改 O(n) 偏移跟踪（去 `list.index` 的 O(n²)）。
+
 ## [0.1.16] - 2026-06-24
 
 ### 新增

--- a/guanlan/web/render.py
+++ b/guanlan/web/render.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 import html as html_lib
 import re
 import xml.etree.ElementTree as _etree  # stdlib，始终可用；只有 markdown 是可选 extra。
+from collections import defaultdict
 from html.parser import HTMLParser as _HTMLParser
 from pathlib import Path
 
@@ -167,6 +168,117 @@ def _wikilink_display(raw: str) -> str:
 _stem_to_path = link_resolution_index
 
 
+# ── raw/ 源引用 → 只读 raw 查看链接 ──────────────────────────────────────────────
+# 正文里指向 `raw/<slug>.md` 的引用，联成前端 `a.rawlink[data-raw]`（点 → 右栏调 `/api/raw/file`
+# 只读内联渲染那篇 raw 源）。与 `[[wikilink]]` 同纪律：**仅真实存在**的 raw 文件联链、其余标灰
+# `span.rawlink.broken`（决策：raw/ 是只读不可变源，引用它的多是 `wiki/sources/` 摘要页 frontmatter/
+# 正文，点链即回看原始素材）。四种写法共用下面的解析归口：
+#   ① 裸路径串（plain text 行内，如「材料见 raw/某案例.md」）—— `_RawPathTreeprocessor` ②路
+#   ② 行内 code（整段恰好是 `raw/<slug>.md`）—— `_CodePathLinkTreeprocessor` 内新分支
+#   ③ `[[raw/<slug>]]`（wikilink 写法，可带/不带 .md）—— `_resolve_wikilink` 内 raw 前缀拦截
+#   ④ markdown 链接 `[文字](raw/<slug>.md)` —— `_RawPathTreeprocessor` ①路（改写 <a href>）
+# 裸路径串正则：`raw/` 须前邻非词/非斜杠（杜绝 `wiki/sources/raw/x.md`、`araw/x.md` 误命中）；
+# slug 字符集对齐 rawio.raw_slug 的 `[\w.\-]`（`\w` 含 CJK）；尾界 `(?![\w\-])` 只挡「`.md` 后接更多
+# 词字/连字符」（防把 `notes.mdx`/`x.mdown` 误截成 `.md`），但**允许后随 `.`**——故句末紧跟 ASCII 句号
+# 的 `raw/x.md.` 仍联链、只把句号留在外面（评审修复：旧的 `(?![\w.\-])` 把句末句号也挡了）。
+# `_RAW_REF_FULL_RE` 供「整段 code / 整段路径」fullmatch（无需边界，靠整体消费定界）。
+_RAW_PATH_RE = re.compile(r"(?<![\w/])raw/[\w.\-]+?\.md(?![\w\-])")
+_RAW_REF_FULL_RE = re.compile(r"raw/([\w.\-]+\.md)")
+
+# rawlink 命中/缺失的样式归口（单点定义，杜绝多处 class/title 字面漂移，评审 reuse）。
+_RAWLINK_BROKEN_TITLE = "raw/ 源不存在"
+
+
+def _raw_name_index(root: Path) -> dict[str, str]:
+    """`raw/*.md` 真实文件名解析表：**精确文件名键**（保大小写）→ 真实名，叠加**无冲突的小写兜底键**
+    （大小写不敏感匹配，但精确优先、撞则不折叠——镜像 `pages.link_resolution_index` 的 fold 纪律）。
+
+    **每次渲染重建**（同 `_stem_to_path` 纪律，不缓存）：投喂/晋级随时增删 raw 源，重扫保新源即时可点、
+    删则标灰。只 `glob("*.md")` 取 raw/ **顶层**（`raw/images/` 等子树非源、天然不入），不读内容。
+    精确优先使「`raw/Foo.md` 与 `raw/foo.md` 在大小写敏感盘上并存」时各按真实名解析、零串台（评审修复
+    旧的纯小写键把二者撞成一个、`raw/foo.md` 误开 `Foo.md`）；小写兜底使「误写大小写」在大小写不敏感盘
+    上仍命中（与 `_safe_raw_file` 行为一致）。
+    """
+    raw = root / "raw"
+    exact: dict[str, str] = {}
+    if raw.is_dir():
+        for path in sorted(raw.glob("*.md")):
+            if path.is_file():
+                exact.setdefault(path.name, path.name)
+    index = dict(exact)
+    groups: dict[str, set[str]] = defaultdict(set)
+    for name in exact:
+        lower = name.lower()
+        if lower not in exact:  # 小写键撞任意精确键 → 不新增（精确优先、撞则不折叠）
+            groups[lower].add(name)
+    for lower, names in groups.items():
+        if len(names) == 1:  # 小写组唯一拥有者才作兜底键；≥2（真撞名）→ 丢弃、保歧义断链不猜
+            index[lower] = next(iter(names))
+    return index
+
+
+def _raw_ref_basename(target: str) -> str | None:
+    """把引用串解析为 `raw/` 顶层文件名 basename（**保大小写、保原扩展名**），非 raw/ 前缀 → None。
+
+    剥 `|别名`/`#锚点`（兼容 `[[raw/x|看案例]]`）、归一斜杠；须 `raw/` 前缀（大小写不敏感）+ 非空尾段；
+    取 basename（raw/ 顶层平铺，`raw/a/b.md` 退化取 `b.md`）。**不**补 `.md`、**不**小写——补 `.md` 与
+    大小写兜底都交给 `_lookup_raw`（按存在性试 `<名>` 与 `<名>.md`）。如此含内部点的 stem（`raw/1.示例报告`）
+    与非 `.md` 资产（`raw/images/x.png`）能被正确区分：前者补 `.md` 命中、后者两试皆空 → 不认领（评审修复
+    旧的「无条件补 `.md`」把 `raw/report.pdf` 之类合法资产链接毁成断链 span）。
+    """
+    head = target.split("|", 1)[0].split("#", 1)[0].strip().replace("\\", "/")
+    prefix, sep, rest = head.partition("/")
+    if not sep or prefix.lower() != "raw" or not rest:
+        return None
+    return rest.rsplit("/", 1)[-1] or None
+
+
+def _lookup_raw(basename: str, raw_index: dict[str, str]) -> str | None:
+    """basename（保大小写、可能带/不带 `.md`）→ 现存 raw 真实文件名 or None。
+
+    依次试：精确 → 小写兜底；若不以 `.md` 结尾，再补 `.md` 试 精确 → 小写。覆盖「含内部点的 stem 省略
+    `.md`」（`1.示例报告`→`1.示例报告.md`）与大小写不敏感匹配；非 `.md` 资产（`x.png`）两试皆空 → None。
+    """
+    cands = [basename] if basename.lower().endswith(".md") else [basename, basename + ".md"]
+    for cand in cands:
+        hit = raw_index.get(cand) or raw_index.get(cand.lower())
+        if hit is not None:
+            return hit
+    return None
+
+
+def _is_raw_md_form(basename: str) -> bool:
+    """basename 形如 raw `.md` 源引用（以 `.md` 结尾、或无扩展名纯 stem）→ True；非 `.md` 扩展名
+    （`.png`/`.pdf` 等资产）→ False。markdown 链接据此决定缺失时「标灰」还是「原样保留 href」——
+    避免把指向 `raw/images/x.png` 之类合法资产链接误毁成断链 span。
+    """
+    return basename.lower().endswith(".md") or "." not in basename
+
+
+def _raw_ref_in_code(content: str) -> str | None:
+    """行内 code 整段（规整后）恰好是 `raw/<slug>.md` → 返回 basename（保大小写），否则 None。
+
+    与裸路径串同口径但用 fullmatch（整段消费定界，无需前后边界）；命令/多 token 代码（`cat raw/x.md`）
+    整体不等于 `raw/<slug>.md` 形 → 不误判（同 `_code_ref_target` 末步整体相等的安全纪律）。
+    """
+    m = _RAW_REF_FULL_RE.fullmatch(content.strip().replace("\\", "/"))
+    return m.group(1) if m is not None else None
+
+
+def _resolve_raw_link(
+    basename: str | None, raw_index: dict[str, str], display: str
+) -> tuple[str, dict[str, str], str] | None:
+    """raw basename（保大小写）→ `(tag, attrib, display)`：命中现存源 `a.rawlink[data-raw]`、缺失
+    `span.rawlink.broken`。`basename` 为 None（非 raw/ 前缀）→ None，交回调用方续判（不拦截）。
+    """
+    if basename is None:
+        return None
+    actual = _lookup_raw(basename, raw_index)
+    if actual is not None:
+        return "a", {"class": "rawlink", "data-raw": actual}, display
+    return "span", {"class": "rawlink broken", "title": _RAWLINK_BROKEN_TITLE}, display
+
+
 def _code_ref_target(content: str, stem_to_path: dict[str, str]) -> str | None:
     """`content` 是【对某现有页的忠实整体引用】才返回其相对路径，否则 None（行内 code 兜底用）。
 
@@ -194,15 +306,24 @@ def _code_ref_target(content: str, stem_to_path: dict[str, str]) -> str | None:
     return target if want in (base, base.removeprefix("wiki/"), base.rsplit("/", 1)[-1]) else None
 
 
-def _resolve_wikilink(raw: str, stem_to_path: dict[str, str]) -> tuple[str, dict[str, str], str]:
+def _resolve_wikilink(
+    raw: str, stem_to_path: dict[str, str], raw_index: dict[str, str]
+) -> tuple[str, dict[str, str], str]:
     """把 `[[…]]` 内部 raw 解析为 `(tag, attrib, display)`：命中现有页 → `a.wikilink[data-page]`，
     断链 → `span.wikilink.broken`。行内 `[[…]]` 与 code 兜底两路共用，杜绝两处样式/类名漂移。
+
+    **`raw/` 前缀优先拦截**：`[[raw/<slug>]]`（可带/不带 .md）指向 raw/ 顶层源——存在 →
+    `a.rawlink[data-raw]`、缺失 → `span.rawlink.broken`（决策：raw/ 只读源引用单列一档、不落到 wiki
+    页解析；`raw/` 是不会与 wiki 页 stem 撞的明确前缀，故拦截无歧义）。非 raw/ 前缀才续走 wiki 解析。
 
     P3.8：经 `resolve_owner`（精确 `link_stem` + fold 兜底）解析，与 check/graph/heal 同一张表、同
     口径——`[[multi_head_attention]]` 命中 `multi-head-attention.md`。**仅 `[[wikilink]]` 走 fold**；
     行内 code 引用（`_code_ref_target`）按精确路径/文件名判定、**不接 fold**（决策P3.8-7 边界）。
     """
     display = _wikilink_display(raw) or raw.strip()
+    raw_link = _resolve_raw_link(_raw_ref_basename(raw), raw_index, display)
+    if raw_link is not None:  # `[[raw/…]]`：raw 源引用单列一档（命中链 / 缺失标灰），不落 wiki 解析
+        return raw_link
     target = resolve_owner(raw, stem_to_path)
     if target is not None:
         return "a", {"class": "wikilink", "data-page": target}, display
@@ -311,29 +432,165 @@ if _HAS_MARKDOWN:
             md.preprocessors.register(_TableHtmlPreprocessor(md), "guanlan_table_html", 24)
 
     class _WikiLinkInlineProcessor(_InlineProcessor):
-        """把 `[[…]]` 渲染为站内锚链（resolved）或标灰 span（断链）。"""
+        """把 `[[…]]` 渲染为站内锚链（resolved）/ raw 源链（`[[raw/…]]`）/ 标灰 span（断链）。"""
 
-        def __init__(self, pattern: str, md, stem_to_path: dict[str, str]) -> None:
+        def __init__(
+            self, pattern: str, md, stem_to_path: dict[str, str], raw_index: dict[str, str]
+        ) -> None:
             super().__init__(pattern, md)
             self._stem_to_path = stem_to_path
+            self._raw_index = raw_index
 
         def handleMatch(self, m, data):  # noqa: N802 (markdown API 命名)
-            tag, attrib, display = _resolve_wikilink(m.group(1), self._stem_to_path)
-            el = _etree.Element(tag, attrib)  # 命中→a[data-page]（前端站内导航，无 href 跳转）
+            tag, attrib, display = _resolve_wikilink(
+                m.group(1), self._stem_to_path, self._raw_index
+            )
+            el = _etree.Element(tag, attrib)  # 命中→a[data-page|data-raw]（前端站内导航，无 href 跳转）
+            # display 不包 AtomicString：让 `[[页|**别名**]]` 的内联格式（强调/code 等）照常渲染（评审修复
+            # 旧的 AtomicString 把别名 markdown 渲成字面）。无嵌套之忧——裸 raw/ 路径串已改走跳过 `<a>` 子树的
+            # `_RawPathTreeprocessor`（树阶段），inline 阶段已无任何模式会回灌 display 套出嵌套 `<a>`。
             el.text = display
             return el, m.start(0), m.end(0)
 
     class _WikiLinkExtension(_Extension):
-        def __init__(self, stem_to_path: dict[str, str]) -> None:
+        def __init__(self, stem_to_path: dict[str, str], raw_index: dict[str, str]) -> None:
             super().__init__()
             self._stem_to_path = stem_to_path
+            self._raw_index = raw_index
 
         def extendMarkdown(self, md) -> None:  # noqa: N802 (markdown API 命名)
             # 优先级 175 高于内置 'link'(160)，确保 [[…]] 先于普通 [text](url) 被吃掉。
             md.inlinePatterns.register(
-                _WikiLinkInlineProcessor(WIKILINK_RE.pattern, md, self._stem_to_path),
+                _WikiLinkInlineProcessor(
+                    WIKILINK_RE.pattern, md, self._stem_to_path, self._raw_index
+                ),
                 "guanlan_wikilink",
                 175,
+            )
+
+    # 不在这些标签的子树里联裸路径串：`a`（链接文字——否则 `[raw/x.md](url)` 会在链接内套出嵌套锚）、
+    # `code`/`pre`（行内代码/代码块——保字面，同决策P4-3）、`span`（断链/rawlink.broken 标灰节点——
+    # 否则 `[raw/exists.md](raw/missing.md)` 经 ① 成 broken span 后，② 会在其内再联出**可点 rawlink 嵌在
+    # 灰 span 里**、且指向另一个源；`[[raw/ghost.md]]` 的灰 span 同理，评审修复）。
+    _RAW_SKIP_SUBTREE = frozenset({"a", "code", "pre", "span"})
+
+    class _RawPathTreeprocessor(_Treeprocessor):
+        """把指向 raw/ 源的引用联成 raw 源链——**两路在树上处理**（非 inline），故可按祖先精确避让：
+
+        ① **markdown 链接** `[文字](raw/<slug>.md)`：命中现存 raw 源 → 改写 `<a href>` 为 `a.rawlink[data-raw]`
+           （**保留链接文字、内联格式如 `<strong>`、作者 title**）；`.md` 形但缺失 → `span.rawlink.broken`；
+           **非 `.md` 扩展名资产**（`raw/images/x.png` 等）→ **原样保留**（不毁合法资产链接）。外链 / 绝对
+           路径 / 非 raw/ 前缀一律不动。
+        ② **裸路径串** `raw/<slug>.md`（正文 plain text）：切文本节点联链，但**跳过 `a`/`code`/`pre`/`span`
+           子树**——这是改用 treeprocessor（而非 inline）的关键：inline 处理器看不到祖先，链接文字
+           `[raw/x.md](url)` 会被回灌再联、套出非法嵌套 `<a>`；树上按祖先跳过则从根上杜绝（含跳过 ① 产出的
+           断链 `span`，否则会在灰 span 里再联出可点 rawlink）。
+
+        ① 先于 ② 跑：① 把命中的 raw/ 链接转成 `a.rawlink`（tag 仍 `a`）、缺失的转成 `span`，② 随即把它们
+        当 `a`/`span` 子树跳过，不会再进去联其链接文字。
+        """
+
+        def __init__(self, md, raw_index: dict[str, str]) -> None:
+            super().__init__(md)
+            self._raw_index = raw_index
+
+        def _split(self, text):
+            """把一段文本按裸 `raw/<slug>.md` 切成 `[str, <a|span>, str, …]`（首尾恒为 str）；无命中 → None。"""
+            if not text or "raw/" not in text:
+                return None
+            matches = list(_RAW_PATH_RE.finditer(text))
+            if not matches:
+                return None
+            frags: list = []
+            last = 0
+            for m in matches:
+                frags.append(text[last : m.start()])
+                tag, attrib, _ = _resolve_raw_link(
+                    _raw_ref_basename(m.group(0)), self._raw_index, m.group(0)
+                )
+                node = _etree.Element(tag, attrib)
+                node.text = m.group(0)
+                frags.append(node)
+                last = m.end()
+            frags.append(text[last:])
+            return frags
+
+        @staticmethod
+        def _insert_nodes(parent, frags, at):
+            """把 `_split` 的 frags 的**元素段**（frags[1],frags[3],…，各以其后字符串作 tail）依次插到
+            `parent` 的 `at` 位置起；首段字符串（frags[0]）由调用方自行安置到 el.text 或前邻 tail。
+            返回插入的元素数（供调用方推进插入锚点，避免 list.index 的 O(n²) 再扫）。"""
+            count = 0
+            i = 1
+            while i < len(frags):
+                node = frags[i]
+                node.tail = frags[i + 1]
+                parent.insert(at + count, node)
+                count += 1
+                i += 2
+            return count
+
+        def _linkify(self, el):
+            # Comment/PI 节点 .tag 是 callable（非字符串）→ 显式跳过（不进其文本联链，纵深防御）。
+            if callable(el.tag) or el.tag in _RAW_SKIP_SUBTREE:
+                return  # 整个子树跳过（链接文字 / 行内代码 / 代码块 / 断链 span）
+            original = list(el)
+            for child in original:  # 先递归子元素（其内部 text）
+                self._linkify(child)
+            # ① 联本元素 .text（新元素插到所有原子元素之前）。
+            inserted = 0
+            frags = self._split(el.text)
+            if frags is not None:
+                el.text = frags[0]
+                inserted = self._insert_nodes(el, frags, 0)
+            # ② 联每个原子元素的 .tail（插到该元素之后）。pos 跟踪当前原 child 在 el 中的实时下标
+            # （= 原序 + 已插入数），免每轮 list(el).index(child) 的 O(n²) 线性再扫（评审 efficiency 修复）。
+            pos = inserted
+            for child in original:
+                frags = self._split(child.tail)
+                if frags is not None:
+                    child.tail = frags[0]
+                    pos += self._insert_nodes(el, frags, pos + 1)
+                pos += 1  # 跳过 child 本身，下一个原 child 紧随其后（含其间已插入的锚）
+
+        def run(self, root):  # noqa: N802 (markdown API 命名)
+            # ① markdown 链接 href 指向 raw/ 源 → rawlink（命中）/ broken（.md 形但缺失）；先于 ② 跑。
+            # list(...) 物化：① 内把 broken 链接的 tag 由 `a`→`span`，避免边迭代边改 iter("a") 匹配标签。
+            for el in list(root.iter("a")):
+                href = el.get("href")
+                if not href:
+                    continue
+                norm = href[2:] if href.startswith("./") else href  # 容 `./raw/x.md`
+                basename = _raw_ref_basename(norm)
+                if basename is None:
+                    continue  # 外链 / 绝对 / 非 raw/ 前缀 → 不动
+                actual = _lookup_raw(basename, self._raw_index)
+                if actual is not None:  # 命中现存 raw 源 → rawlink（保留链接文字/格式与作者 title）
+                    title = el.get("title")
+                    el.attrib.clear()  # 丢 href（改站内导航，无 href 跳转）
+                    el.set("class", "rawlink")
+                    el.set("data-raw", actual)
+                    if title:  # 保留作者 title 提示（评审修复：旧的 attrib.clear 把 title 一并丢了）
+                        el.set("title", title)
+                elif _is_raw_md_form(basename):  # `.md` 形（或无扩展名 stem）但不存在 → 标灰
+                    el.attrib.clear()
+                    el.tag = "span"
+                    el.set("class", "rawlink broken")
+                    el.set("title", _RAWLINK_BROKEN_TITLE)
+                # else: 非 `.md` 扩展名资产（raw/images/x.png 等）→ 链接原样保留，不毁 href（评审修复）。
+            # ② 裸路径串 → rawlink/broken（按祖先跳过 a/code/pre/span，杜绝在链接文字/代码/断链 span 里联）。
+            self._linkify(root)
+
+    class _RawPathExtension(_Extension):
+        def __init__(self, raw_index: dict[str, str]) -> None:
+            super().__init__()
+            self._raw_index = raw_index
+
+        def extendMarkdown(self, md) -> None:  # noqa: N802 (markdown API 命名)
+            # 优先级 6 > safelink(5)：在 safelink 前把 raw/ href 转成无 href 的 rawlink（raw/ 本就安全，
+            # 顺序其实无碍，取 6 只为在同族 treeprocessor 中先跑、语义清晰）。核心 inline(20) 早已建好 <a>。
+            md.treeprocessors.register(
+                _RawPathTreeprocessor(md, self._raw_index), "guanlan_rawpath", 6
             )
 
     class _CodePathLinkTreeprocessor(_Treeprocessor):
@@ -350,9 +607,10 @@ if _HAS_MARKDOWN:
         若再把内层 code 转成 `<a>` 会产生嵌套锚（非法 HTML，浏览器会拆链、连累内外两个链接）。
         """
 
-        def __init__(self, md, stem_to_path: dict[str, str]) -> None:
+        def __init__(self, md, stem_to_path: dict[str, str], raw_index: dict[str, str]) -> None:
             super().__init__(md)
             self._stem_to_path = stem_to_path
+            self._raw_index = raw_index
 
         def run(self, root):  # noqa: N802 (markdown API 命名)
             # 排除已在 <pre>（缩进代码块）或 <a>（code 作链接文字）内的 code：前者保字面，
@@ -367,8 +625,17 @@ if _HAS_MARKDOWN:
                     continue  # 代码块内 / 链接内 / 含子元素 / 空 → 不碰
                 raw_wikilink = _code_wikilink_raw(el.text)
                 if raw_wikilink is not None:
-                    # 整段就是 `[[…]]`：与行内 [[…]] 完全同路（_resolve_wikilink），就地改写。
-                    _retag(el, *_resolve_wikilink(raw_wikilink, self._stem_to_path))
+                    # 整段就是 `[[…]]`：与行内 [[…]] 完全同路（_resolve_wikilink，含 `[[raw/…]]` 拦截）。
+                    _retag(
+                        el, *_resolve_wikilink(raw_wikilink, self._stem_to_path, self._raw_index)
+                    )
+                    continue
+
+                # 整段恰好是 `raw/<slug>.md`：raw 源引用（存在链 / 缺失标灰），**先于** wiki 页解析判定——
+                # 否则 `raw/x.md` 的 link_stem=`x` 可能误命中同名 wiki 页 `x.md`，把 raw 引用错链到 wiki。
+                raw_key = _raw_ref_in_code(el.text)
+                if raw_key is not None:
+                    _retag(el, *_resolve_raw_link(raw_key, self._raw_index, el.text.strip()))
                     continue
 
                 # 仅当整段是【对某现有页的忠实引用】才联链：放行含空格的合法页名，
@@ -381,14 +648,15 @@ if _HAS_MARKDOWN:
             return None
 
     class _CodePathLinkExtension(_Extension):
-        def __init__(self, stem_to_path: dict[str, str]) -> None:
+        def __init__(self, stem_to_path: dict[str, str], raw_index: dict[str, str]) -> None:
             super().__init__()
             self._stem_to_path = stem_to_path
+            self._raw_index = raw_index
 
         def extendMarkdown(self, md) -> None:  # noqa: N802 (markdown API 命名)
-            # 树处理阶段跑（行内 code 节点此时已生成）；data-page 无 href，与 safelink 不冲突。
+            # 树处理阶段跑（行内 code 节点此时已生成）；data-page/data-raw 无 href，与 safelink 不冲突。
             md.treeprocessors.register(
-                _CodePathLinkTreeprocessor(md, self._stem_to_path),
+                _CodePathLinkTreeprocessor(md, self._stem_to_path, self._raw_index),
                 "guanlan_codepathlink",
                 4,
             )
@@ -401,7 +669,9 @@ def render_markdown(
 
     始终带两道安全闸：`_EscapeHtmlExtension`（关原始 HTML 透传）+ `_SafeLinkExtension`
     （中和 javascript:/data: 链接）。给了 `wiki` 才挂 `[[wikilink]]` 重写（解析到该库页面），
-    并对【整段精确解析到现有页】的行内 `<code>` 破例联链（兜底 LLM 把源出处写成路径+反引号）。
+    并对【整段精确解析到现有页】的行内 `<code>` 破例联链（兜底 LLM 把源出处写成路径+反引号）；
+    同时把指向 `raw/<slug>.md` 的引用（裸路径串 / 行内 code / `[[raw/…]]` 三写法）联成只读 raw 源链
+    `a.rawlink[data-raw]`（仅真实存在的 raw 文件，缺失标灰），raw 目录由 `wiki.parent/raw` 推出。
     给了 `image_src`（`(相对路径) -> URL` 可调用）才挂库内相对 `<img>` 改写——供 raw 预览把
     `images/<slug>/…` 指向本地图片端点。`allow_tables=True` 才对原始 `<table>` HTML 破例
     （allowlist 消毒后还原，供 raw 预览显示 mineru/marker 的复杂表）——两者都默认关，wiki/chat
@@ -416,9 +686,11 @@ def render_markdown(
         _SafeLinkExtension(),  # 安全：中和 javascript:/data: 链接。
     ]
     if wiki is not None:
-        stem_map = _stem_to_path(wiki)  # 单次扫库，两个扩展共享（避免重复 rglob）。
-        extensions.append(_WikiLinkExtension(stem_map))
-        extensions.append(_CodePathLinkExtension(stem_map))
+        stem_map = _stem_to_path(wiki)  # 单次扫库，wiki/code 两扩展共享（避免重复 rglob）。
+        raw_index = _raw_name_index(wiki.parent)  # raw/ 顶层 .md 真实文件名集（每渲染重扫，同 stem_map 纪律）。
+        extensions.append(_WikiLinkExtension(stem_map, raw_index))
+        extensions.append(_CodePathLinkExtension(stem_map, raw_index))
+        extensions.append(_RawPathExtension(raw_index))  # 裸 raw/<slug>.md 路径串 + markdown 链接 href→rawlink。
     if image_src is not None:
         extensions.append(_RawImageExtension(image_src))
     if allow_tables:

--- a/guanlan/web/static/app.css
+++ b/guanlan/web/static/app.css
@@ -219,6 +219,9 @@ body.col-resizing { user-select: none; cursor: col-resize; }
 .msg.bot.rendered a { color: var(--lan-deep); }
 .msg.bot.rendered a.wikilink { color: var(--lan-deep); text-decoration: none; border-bottom: 1px dotted var(--lan-deep); cursor: pointer; }
 .msg.bot.rendered a.wikilink.broken { color: var(--lan-ink-soft); border-bottom-color: var(--lan-mist); cursor: default; }
+/* raw 源链：dashed 下划线区别于 wikilink 的 dotted（点 → 右栏只读渲染那篇 raw 源）。 */
+.msg.bot.rendered a.rawlink { color: var(--lan-deep); text-decoration: none; border-bottom: 1px dashed var(--lan-deep); cursor: pointer; }
+.msg.bot.rendered a.rawlink.broken { color: var(--lan-ink-soft); border-bottom-color: var(--lan-mist); cursor: default; }
 
 /* mermaid 渲染图（P4.13）：```mermaid 块经 enhanceMermaid 换成的 <figure>。SVG 自适应宽、不溢出；
    渲染失败时 .mermaid-error 徽标贴在保留的 <pre> 源码上方。wiki 单页 / 对话气泡 / 预览共用。 */
@@ -284,6 +287,18 @@ body.col-resizing { user-select: none; cursor: col-resize; }
 .wiki-view a.wikilink { color: var(--lan-ripple); text-decoration: none; border-bottom: 1px dotted var(--lan-ripple); cursor: pointer; transition: color .15s; }
 .wiki-view a.wikilink:hover { color: var(--lan-deep); }
 .wiki-view .wikilink.broken { color: var(--lan-ink-soft); border-bottom: 1px dotted var(--lan-mist); cursor: default; } /* 水静无澜 */
+/* raw 源链：dashed 区别于 wikilink 的 dotted（点 → 右栏 {kind:"raw"} 只读渲染 raw 源）；断链同款灰。 */
+.wiki-view a.rawlink { color: var(--lan-deep); text-decoration: none; border-bottom: 1px dashed var(--lan-ripple); cursor: pointer; transition: color .15s; }
+.wiki-view a.rawlink:hover { color: var(--lan-ripple); }
+.wiki-view .rawlink.broken { color: var(--lan-ink-soft); border-bottom: 1px dashed var(--lan-mist); cursor: default; }
+
+/* raw 只读源视图（{kind:"raw"}）：banner 标明「原始素材·只读」+ raw/ 路径 + 「在新标签打开」逃生口；
+   正文 .raw-body 复用 .rendered 富排版。banner 用 foam 底 + 深澜左纲，把 raw/wiki 边界标清楚。 */
+.wiki-view .raw-banner { display: flex; align-items: center; gap: .5rem; flex-wrap: wrap; margin: 0 0 .7rem; padding: .4rem .6rem; background: var(--lan-foam); border-left: 3px solid var(--lan-deep); border-radius: 0 4px 4px 0; font-size: .82rem; }
+.wiki-view .raw-banner-label { font-weight: 600; color: var(--lan-deep); }
+.wiki-view .raw-banner-path { color: var(--lan-ink-soft); font-family: ui-monospace, SFMono-Regular, Menlo, monospace; word-break: break-all; }
+.wiki-view .raw-banner-pop { margin-left: auto; border: 1px solid var(--lan-mist); background: var(--lan-surface); color: var(--lan-deep); border-radius: 5px; padding: .15rem .5rem; font-size: .78rem; cursor: pointer; white-space: nowrap; }
+.wiki-view .raw-banner-pop:hover { background: var(--lan-ripple); border-color: var(--lan-ripple); color: #fff; }
 
 /* ── 对话输入框（底部满宽，OpenAI 风格圆角 composer，承观澜水墨 + 澜配色） ──
    外层 .composer 是带边框/圆角的卡片（focus-within 时下沉澜纹边）；内含附件徽章行、

--- a/guanlan/web/static/boot.js
+++ b/guanlan/web/static/boot.js
@@ -57,10 +57,14 @@
 $("#lang-btn").addEventListener("click", toggleLang);
 initLang();
 
-// 先拉页面再进"列表"视图（首页）——启动即显示 Concept 列表。
-// 仅当用户尚未导航时才进首页：否则页面慢加载期间用户已输入的搜索会被这次空首页覆盖
-// （loadPages 解析后会就地重渲染当前 index 条目，故用户的搜索结果照常出现）。
-loadPages().then(() => { if (histPos < 0) navigate({ kind: "index", query: "" }); });
+// 先拉页面再进初始视图——默认显示 Concept 列表；`?raw=<name>` 弹出页则直开该 raw 源（「在新标签
+// 打开」用，供边看 wiki 边对照原始素材）。仅当用户尚未导航时才进，否则页面慢加载期间用户已输入的
+// 搜索会被覆盖（loadPages 解析后会就地重渲染当前 index 条目，故用户的搜索结果照常出现）。
+loadPages().then(() => {
+  if (histPos >= 0) return; // 用户已自行导航（搜索/点页）→ 不覆盖
+  const wantRaw = new URL(window.location.href).searchParams.get("raw");
+  navigate(wantRaw ? { kind: "raw", name: wantRaw } : { kind: "index", query: "" });
+});
 
 // 启动协调（P4.9）：先拉一次 /api/info 取进程默认姿态 + reader 标志，**再**按模式恢复 ?c= 会话——
 // 二者本是两段独立异步、会赛跑；合一后 reader 标志在恢复策略选择前就绪（reader 走按-id 探针、不枚举）。

--- a/guanlan/web/static/chat.js
+++ b/guanlan/web/static/chat.js
@@ -670,10 +670,13 @@ function clearHeartbeat(botEl) {
   }
 }
 
-// 对话气泡里的 [[wikilink]]（来自渲染后的答案）点了切到右栏 wiki 单页。
+// 对话气泡里的 [[wikilink]] / raw 源链（来自渲染后的答案）点了切到右栏：wiki 单页 / 只读 raw 源。
+// 左栏=对话、右栏=查看器（与既有 wikilink 行为一致，气泡滚动位置不丢；断链 span 无 data-* 不可点）。
 $("#chat-log").addEventListener("click", (e) => {
   const a = e.target.closest("a.wikilink[data-page]");
-  if (a) { e.preventDefault(); navigate({ kind: "page", path: a.dataset.page }); }
+  if (a) { e.preventDefault(); navigate({ kind: "page", path: a.dataset.page }); return; }
+  const r = e.target.closest("a.rawlink[data-raw]");
+  if (r) { e.preventDefault(); navigate({ kind: "raw", name: r.dataset.raw }); }
 });
 
 async function sendChat(message, attachments) {

--- a/guanlan/web/static/i18n.js
+++ b/guanlan/web/static/i18n.js
@@ -49,6 +49,11 @@ window.I18N = {
     "wiki.loadFail": "加载页面失败：{0}（请重试或检查服务端）",
     "wiki.emptyAll": "暂无页面",
     "wiki.emptyMatch": "无匹配页面",
+    // —— raw 只读源视图（正文/对话里点 a.rawlink 进来）——
+    "raw.banner": "原始素材 · 只读",
+    "raw.openInTab": "在新标签打开",
+    "raw.loading": "加载原始素材…",
+    "raw.openFail": "打开原始素材失败：{0}",
     "search.searching": "检索中…",
     "search.head": "命中 {0} 页 · 检索 {1} 页",
     "search.empty": "无命中：{0}",
@@ -420,6 +425,11 @@ window.I18N = {
     "wiki.loadFail": "Failed to load pages: {0} (retry or check the server)",
     "wiki.emptyAll": "No pages yet",
     "wiki.emptyMatch": "No matching pages",
+    // —— raw read-only source view (reached via a.rawlink in body / chat) ——
+    "raw.banner": "Source material · read-only",
+    "raw.openInTab": "Open in new tab",
+    "raw.loading": "Loading source material…",
+    "raw.openFail": "Failed to open source material: {0}",
     "search.searching": "Searching…",
     "search.head": "{0} hits · {1} pages searched",
     "search.empty": "No hits: {0}",

--- a/guanlan/web/static/i18n_apply.js
+++ b/guanlan/web/static/i18n_apply.js
@@ -22,6 +22,7 @@ function rerenderDynamic() {
   const cur = currentView();
   if (cur && cur.kind === "index") renderIndex(cur);
   else if (cur && cur.kind === "page") repaintPageChrome();
+  else if (cur && cur.kind === "raw") repaintRawChrome(); // raw 源态：纯重绘 banner（吃缓存，不重拉）
   // 搜索态：用缓存结果纯重绘头部（命中/检索计数）+ 空/失败态文案（吃 view.results，不重拉 /api/search，
   // P5.1）。在飞搜索（尚无 results）无需在此重绘——其 doSearch 回调落地时按当时语言 t() 自然出新语言。
   else if (cur && cur.kind === "search" && cur.results) paintSearch(cur);

--- a/guanlan/web/static/wiki.js
+++ b/guanlan/web/static/wiki.js
@@ -50,6 +50,8 @@ function renderView(view) {
   } else if (view.kind === "search") {
     $("#wiki-search").value = view.query || "";
     renderSearch(view);
+  } else if (view.kind === "raw") {
+    renderRaw(view.name); // 只读 raw 源（正文/对话里点 a.rawlink 进来），复用历史栈、一键「←」回原页
   } else {
     renderPage(view.path);
   }
@@ -220,6 +222,61 @@ async function renderPage(path) {
   }
 }
 
+// ── 只读 raw 源视图（{kind:"raw", name}）─────────────────────────────────────
+// 正文/对话里指向现存 raw/<slug>.md 的 a.rawlink 点击落到这里：复用 /api/raw/file（与 ingest 选单
+// 预览同一只读渲染端点、同形 {meta,html}）内联渲染进右栏，压历史栈、一键「←」回引用它的原页。
+// banner 标明「只读原始素材」把 raw/wiki 边界标清楚，并给个「在新标签打开」逃生口供并排对照源。
+let lastRaw = null; // {name, data}：当前 raw 源态缓存，供语言切换纯重绘 banner（不重拉 /api/raw/file）
+
+function paintRaw(data, name) {
+  const view = $("#wiki-view");
+  const banner = document.createElement("div"); // 只读原始素材横幅（chrome 走 t()）
+  banner.className = "raw-banner";
+  const label = document.createElement("span");
+  label.className = "raw-banner-label";
+  label.textContent = t("raw.banner");
+  const path = document.createElement("span");
+  path.className = "raw-banner-path";
+  path.textContent = `raw/${name}`; // textContent：文件名按字面显示，无注入
+  const pop = document.createElement("button"); // 「在新标签打开」：开 /?raw= 弹出页，供边看 wiki 边对照源
+  pop.type = "button";
+  pop.className = "raw-banner-pop";
+  pop.textContent = t("raw.openInTab");
+  pop.title = t("raw.openInTab");
+  pop.addEventListener("click", () =>
+    window.open(`/?raw=${encodeURIComponent(name)}`, "_blank", "noopener")
+  );
+  banner.append(label, path, pop);
+  const body = document.createElement("div");
+  body.className = "raw-body rendered";
+  body.innerHTML = data.html; // render_page 已 sanitize（同 /api/page）
+  view.innerHTML = "";
+  view.append(banner, body);
+  enhanceContent(body); // 富渲染正文：```mermaid→图 / ```X→高亮 / $…$→公式（同 paintPage，仅作用于正文非 banner）
+}
+
+// 语言切换时纯重绘当前 raw 源的 banner（吃缓存数据，绝不重拉 /api/raw/file，同 repaintPageChrome）。
+function repaintRawChrome() {
+  const cur = currentView();
+  if (cur && cur.kind === "raw" && lastRaw && lastRaw.name === cur.name) paintRaw(lastRaw.data, cur.name);
+}
+
+async function renderRaw(name) {
+  const tok = ++renderToken; // 复用单页渲染序号：导航走（回退/搜索/续进）即丢弃迟到响应
+  searchToken++; // 导航离开搜索 → 作废在飞的远端搜索响应（同 renderPage，防 stale-overwrite）
+  const view = $("#wiki-view");
+  view.innerHTML = `<p class="muted">${escapeHtml(t("raw.loading"))}</p>`;
+  try {
+    const data = await getJSON(`/api/raw/file?name=${encodeURIComponent(name)}`);
+    if (tok !== renderToken) return;
+    lastRaw = { name, data }; // 缓存供语言切换纯重绘
+    paintRaw(data, name);
+  } catch (e) {
+    if (tok !== renderToken) return;
+    view.innerHTML = `<p class="muted">${escapeHtml(t("raw.openFail", e.message))}</p>`;
+  }
+}
+
 $("#wiki-home").addEventListener("click", () => navigate({ kind: "index", query: "" }));
 $("#wiki-back").addEventListener("click", goBack);
 $("#wiki-fwd").addEventListener("click", goForward);
@@ -239,8 +296,10 @@ $("#wiki-search").addEventListener("input", (e) => {
   }
 });
 
-// 站内 wikilink 导航：事件委托到合并视图，续进单页历史。
+// 站内 wikilink / raw 源链导航：事件委托到合并视图，续进历史（断链 span 无 data-* → 不命中、不可点）。
 $("#wiki-view").addEventListener("click", (e) => {
   const a = e.target.closest("a.wikilink[data-page]");
-  if (a) { e.preventDefault(); navigate({ kind: "page", path: a.dataset.page }); }
+  if (a) { e.preventDefault(); navigate({ kind: "page", path: a.dataset.page }); return; }
+  const r = e.target.closest("a.rawlink[data-raw]");
+  if (r) { e.preventDefault(); navigate({ kind: "raw", name: r.dataset.raw }); }
 });

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -386,6 +386,242 @@ def test_render_markdown_code_wrapped_wikilink_is_tolerated(client, kb) -> None:
     assert "wikilink" not in fenced
 
 
+# ───────────── raw/ 源引用联链（正文/对话里点 a.rawlink → 右栏只读看 raw 源） ─────────────
+
+
+def test_render_markdown_raw_ref_linkifies_existing(client, kb) -> None:
+    """raw/<slug>.md 引用（裸路径串 / 行内 code / [[raw/…]] 三写法）→ a.rawlink[data-raw]，仅存在文件联链。"""
+    from guanlan.web.render import render_markdown
+
+    (kb / "raw" / "某案例.md").write_text("# 案例\n正文足够长。", encoding="utf-8")
+    wiki = kb / "wiki"
+
+    for text in (
+        "材料见 raw/某案例.md 一节。",  # 裸路径串
+        "源出处：`raw/某案例.md`",  # 行内 code
+        "见 [[raw/某案例]]",  # wikilink（不带 .md）
+        "见 [[raw/某案例.md]]",  # wikilink（带 .md）
+    ):
+        html = render_markdown(text, wiki)
+        assert 'class="rawlink"' in html, text
+        assert 'data-raw="某案例.md"' in html, text
+        assert html.count("<a ") == 1, f"不应套出嵌套 <a>（AtomicString 防自我重入）：{html}"
+        assert "rawlink broken" not in html, text
+
+    # 别名写法显示别名、仍联到该源
+    html = render_markdown("见 [[raw/某案例|看这个案例]]", wiki)
+    assert 'data-raw="某案例.md"' in html and ">看这个案例</a>" in html
+
+
+def test_render_markdown_raw_ref_missing_greyed(client, kb) -> None:
+    """指向不存在 raw 文件的引用 → span.rawlink.broken（标灰、不可点、无 data-raw）。"""
+    from guanlan.web.render import render_markdown
+
+    wiki = kb / "wiki"
+    for text in ("材料见 raw/不存在.md。", "源：`raw/missing.md`", "见 [[raw/ghost]]"):
+        html = render_markdown(text, wiki)
+        assert "rawlink broken" in html, text
+        assert "data-raw" not in html, text  # 断链不可点
+
+
+def test_render_markdown_raw_ref_not_confused_with_wiki_page(client, kb) -> None:
+    """`raw/x.md` 即便存在同名 wiki 页，也联到 raw 源（rawlink）、绝不误链 wiki（data-page）。"""
+    from guanlan.web.render import render_markdown
+
+    (kb / "raw" / "夜审.md").write_text("原始笔录", encoding="utf-8")
+    write_page(kb, "wiki/sources/夜审.md", type="source", body="摘要正文足够长。")
+    wiki = kb / "wiki"
+
+    html = render_markdown("源出处：`raw/夜审.md`", wiki)
+    assert 'class="rawlink"' in html and 'data-raw="夜审.md"' in html
+    assert "data-page" not in html  # 没有误链到同名 wiki 页
+
+    # 而裸 [[夜审]]（无 raw/ 前缀）仍按 wiki 页解析，不受影响
+    html2 = render_markdown("见 [[夜审]]", wiki)
+    assert 'data-page="wiki/sources/夜审.md"' in html2 and "rawlink" not in html2
+
+
+def test_render_markdown_raw_ref_markdown_link_rewritten(client, kb) -> None:
+    """`[文字](raw/x.md)` 的 href 改写为 rawlink（保留链接文字/内联格式）；命中链 / 缺失标灰 / 外链不动。"""
+    from guanlan.web.render import render_markdown
+
+    (kb / "raw" / "案卷.md").write_text("x", encoding="utf-8")
+    wiki = kb / "wiki"
+
+    link = render_markdown("[看案例](raw/案卷.md)", wiki)
+    assert 'class="rawlink"' in link and 'data-raw="案卷.md"' in link
+    assert ">看案例</a>" in link and "href=" not in link  # 保留链接文字、丢 href（改站内导航）
+
+    # 链接文字含内联格式 → 格式不丢；且不套出嵌套 <a>（曾是 inline 处理器的隐患）
+    fmt = render_markdown("[**强调**](raw/案卷.md)", wiki)
+    assert "<strong>强调</strong>" in fmt and fmt.count("<a ") == 1
+
+    # 文字本身就是 raw 路径（作者常这么写）也只出一个 <a>，无嵌套
+    same = render_markdown("[raw/案卷.md](raw/案卷.md)", wiki)
+    assert same.count("<a ") == 1 and 'data-raw="案卷.md"' in same
+
+    # ./ 前缀容错
+    dot = render_markdown("[看](./raw/案卷.md)", wiki)
+    assert 'data-raw="案卷.md"' in dot
+
+    # 指向不存在 raw 文件的链接 → 标灰 span（保留文字、不可点）
+    miss = render_markdown("[缺失源](raw/不存在.md)", wiki)
+    assert "rawlink broken" in miss and ">缺失源</span>" in miss and "data-raw" not in miss
+
+    # 外链 / 绝对路径不动（href 含 raw/ 但非库内相对 raw/ 前缀）
+    ext = render_markdown("[外链](https://x.com/raw/y.md)", wiki)
+    assert 'href="https://x.com/raw/y.md"' in ext and "rawlink" not in ext
+
+
+def test_render_markdown_raw_ref_command_and_fenced_literal(client, kb) -> None:
+    """`cat raw/x.md` 命令 code 不联（整段非 raw 路径）；围栏代码块字面保留（决策P4-3）。"""
+    from guanlan.web.render import render_markdown
+
+    (kb / "raw" / "案卷.md").write_text("x", encoding="utf-8")
+    wiki = kb / "wiki"
+    cmd = render_markdown("跑 `cat raw/案卷.md`", wiki)
+    assert "<code>cat raw/案卷.md</code>" in cmd and "rawlink" not in cmd
+    fenced = render_markdown("```\nraw/案卷.md\n```", wiki)
+    assert "rawlink" not in fenced
+
+
+def test_render_markdown_raw_ref_no_clickable_inside_broken(client, kb) -> None:
+    """评审修复：断链 span 内不得再联出可点 rawlink（`span` 已入 _RAW_SKIP_SUBTREE）。
+
+    `[raw/exists.md](raw/missing.md)`：① 先把缺失 md 链接转成 broken span，② 不得再钻进去把其文字
+    `raw/exists.md` 联成嵌在灰 span 里、却指向**另一个**源的可点 rawlink。`[[raw/ghost.md]]` 同理。
+    """
+    from guanlan.web.render import render_markdown
+
+    (kb / "raw" / "存在.md").write_text("x", encoding="utf-8")
+    wiki = kb / "wiki"
+    html = render_markdown("[raw/存在.md](raw/缺失.md)", wiki)
+    assert "rawlink broken" in html
+    assert "<a " not in html  # 灰 span 内无可点 <a>（修复前会嵌一个 data-raw=存在.md 的 rawlink）
+    assert "data-raw" not in html
+    # 灰 wikilink span（display 含 .md 路径）同样不被二次联
+    g = render_markdown("见 [[raw/ghost.md]]", wiki)
+    assert "rawlink broken" in g and "<a " not in g
+
+
+def test_render_markdown_raw_ref_nonmd_asset_link_preserved(client, kb) -> None:
+    """评审修复：markdown 链接指向**非 .md 资产**（现存或不存）→ 原样保留 href，不毁成断链 span。"""
+    from guanlan.web.render import render_markdown
+
+    (kb / "raw" / "report.pdf").write_text("x", encoding="utf-8")
+    (kb / "raw" / "images").mkdir(exist_ok=True)
+    (kb / "raw" / "images" / "diagram.png").write_text("x", encoding="utf-8")
+    wiki = kb / "wiki"
+    for text, href in (
+        ("[报告](raw/report.pdf)", "raw/report.pdf"),
+        ("[图](raw/images/diagram.png)", "raw/images/diagram.png"),
+    ):
+        html = render_markdown(text, wiki)
+        assert f'href="{href}"' in html and "rawlink" not in html, text
+
+
+def test_render_markdown_raw_ref_internal_dot_stem_and_title(client, kb) -> None:
+    """评审修复：含内部点的 stem 省略 .md 仍命中（按存在性试 `<名>` 与 `<名>.md`）；markdown 链接 title 保留。"""
+    from guanlan.web.render import render_markdown
+
+    (kb / "raw" / "1.示例报告.md").write_text("x", encoding="utf-8")
+    wiki = kb / "wiki"
+    # [[raw/1.示例报告]]（无 .md，内部点）命中 1.示例报告.md
+    html = render_markdown("见 [[raw/1.示例报告]]", wiki)
+    assert 'data-raw="1.示例报告.md"' in html
+    # markdown 链接 title 不被 attrib.clear 丢掉
+    titled = render_markdown('[看](raw/1.示例报告.md "作者备注")', wiki)
+    assert 'class="rawlink"' in titled and 'title="作者备注"' in titled
+
+
+def test_render_markdown_raw_ref_trailing_period_linkifies(client, kb) -> None:
+    """评审修复：句末紧跟 ASCII 句号的裸路径 `raw/x.md.` 仍联链，只把句号留在锚外。"""
+    from guanlan.web.render import render_markdown
+
+    (kb / "raw" / "案例.md").write_text("x", encoding="utf-8")
+    wiki = kb / "wiki"
+    html = render_markdown("See the file raw/案例.md.", wiki)
+    assert 'class="rawlink"' in html and 'data-raw="案例.md"' in html
+    assert html.rstrip().endswith(".</p>")  # 句号留在 rawlink 之外
+
+
+def test_render_markdown_wikilink_alias_keeps_inline_formatting(client, kb) -> None:
+    """评审修复（既有 wikilink 行为回归）：[[页|**别名**]] 的别名 markdown 仍渲染（去掉 AtomicString）。"""
+    from guanlan.web.render import render_markdown
+
+    write_page(kb, "wiki/entities/Foo.md", type="entity", body="正文足够长。")
+    wiki = kb / "wiki"
+    html = render_markdown("见 [[Foo|**重点**]]", wiki)
+    assert "<strong>重点</strong>" in html and 'data-page="wiki/entities/Foo.md"' in html
+
+
+def test_raw_name_index_case_collision_exact_first(client, kb) -> None:
+    """评审修复：大小写敏感盘上 raw/Foo.md 与 raw/foo.md 并存时，各按真实名精确解析、零串台。
+
+    大小写不敏感盘（macOS 默认）两次写命中同一文件、无法构造同名异写 → 跳过；大小写匹配仍由
+    `test_raw_name_index_case_insensitive_fallback` 覆盖。
+    """
+    from guanlan.web.render import _lookup_raw, _raw_name_index
+
+    (kb / "raw" / "Foo.md").write_text("X", encoding="utf-8")
+    (kb / "raw" / "foo.md").write_text("y", encoding="utf-8")
+    if sorted(p.name for p in (kb / "raw").glob("*.md")) != ["Foo.md", "foo.md"]:
+        pytest.skip("文件系统大小写不敏感，无法构造 Foo.md / foo.md 并存")
+    idx = _raw_name_index(kb)
+    assert _lookup_raw("foo.md", idx) == "foo.md"  # 精确命中、不串到 Foo.md
+    assert _lookup_raw("Foo.md", idx) == "Foo.md"
+
+
+def test_raw_name_index_case_insensitive_fallback(client, kb) -> None:
+    """评审修复：无冲突时小写兜底键仍命中——`raw/Foo.md` 误写成 `foo.md` 也解析到真实名 `Foo.md`。"""
+    from guanlan.web.render import _lookup_raw, _raw_name_index
+
+    (kb / "raw" / "Foo.md").write_text("x", encoding="utf-8")
+    idx = _raw_name_index(kb)
+    assert _lookup_raw("Foo.md", idx) == "Foo.md"  # 精确
+    assert _lookup_raw("foo.md", idx) == "Foo.md"  # 小写兜底（无冲突时）
+
+
+def test_render_markdown_raw_ref_inert_without_wiki(client, kb) -> None:
+    """不给 wiki（对话裸渲染无库路径）时不做 raw 联链——保 P4 既有姿态。"""
+    from guanlan.web.render import render_markdown
+
+    assert "rawlink" not in render_markdown("材料见 raw/某案例.md。")
+
+
+def test_api_page_links_existing_raw_source(client, kb) -> None:
+    """端到端：/api/page 渲染的 wiki 页正文引用现存 raw/<slug>.md → 输出可点 a.rawlink[data-raw]。"""
+    (kb / "raw" / "s01-夜审笔录.md").write_text("原始笔录正文。", encoding="utf-8")
+    write_page(
+        kb,
+        "wiki/sources/s01-夜审笔录.md",
+        type="source",
+        body="原始材料：`raw/s01-夜审笔录.md`，详见正文足够长。",
+    )
+    resp = client.get("/api/page", params={"path": "wiki/sources/s01-夜审笔录.md"})
+    assert resp.status_code == 200
+    html = resp.json()["html"]
+    assert 'class="rawlink"' in html and 'data-raw="s01-夜审笔录.md"' in html
+
+
+def test_api_raw_file_renders_source(client, kb) -> None:
+    """raw 源只读渲染端点（右栏 {kind:"raw"} 调它）：渲染 .md、越界/缺失 4xx。"""
+    (kb / "raw" / "s01-夜审笔录.md").write_text("# 夜审\n正文。", encoding="utf-8")
+    resp = client.get("/api/raw/file", params={"name": "s01-夜审笔录.md"})
+    assert resp.status_code == 200 and "<h1>" in resp.json()["html"]
+    assert client.get("/api/raw/file", params={"name": "../wiki/index.md"}).status_code in (404, 409)
+    assert client.get("/api/raw/file", params={"name": "nope.md"}).status_code == 404
+
+
+def test_frontend_wires_raw_link_navigation() -> None:
+    """前端把 a.rawlink[data-raw] 点击路由到右栏 {kind:"raw"} 视图（右栏 wiki-view + 左栏 chat-log 两处委托）。"""
+    src = _FRONTEND_JS_SRC
+    assert "a.rawlink[data-raw]" in src
+    assert 'kind: "raw"' in src
+    assert "/api/raw/file?name=" in src  # 右栏 raw 视图复用只读渲染端点
+    assert src.count("a.rawlink[data-raw]") >= 2  # 右栏 + 对话气泡两处点击委托
+
+
 def test_configure_agent_log_writes_and_is_idempotent(kb) -> None:
     """会话日志像 CLI 那样落 <kb>/agentao.log；重复配置不重挂 handler（不会把每行写多遍）。"""
     from guanlan.web import chat as chatmod


### PR DESCRIPTION
## 做什么

wiki 单页（`/api/page`）与对话答案渲染时，把指向**现存** `raw/<slug>.md` 的引用联成可点的 `a.rawlink[data-raw]`：点击在**右栏内联**调既有 `/api/raw/file` 只读渲染那篇原始素材（复用单页历史栈、一键「←」回引用它的原页；左栏对话气泡点亦切右栏，与既有 `[[wikilink]]` 行为一致）。

识别**四种写法**（口径由用户敲定）：
1. 裸路径串 `raw/x.md`（plain text 行内）
2. 整段恰好是 `raw/x.md` 的行内 code
3. `[[raw/x]]`（wikilink，带/不带 `.md`、支持 `|别名`）
4. markdown 链接 `[文字](raw/x.md)`

与 `[[wikilink]]` 同纪律——**仅真实存在**的 raw 文件联链，缺失标灰 `span.rawlink.broken`（dashed 区别于 wikilink 的 dotted）。后端 `/api/raw/file`·`/api/raw` **零改动**（reader 下仍注册）；右栏新增 `{kind:"raw"}` 视图（banner 标明「原始素材·只读」+「在新标签打开」逃生口经 `/?raw=` 弹出 SPA）。

裸路径串与 markdown 链接走树处理器 `_RawPathTreeprocessor`（按祖先跳过 `a`/`code`/`pre`/`span`），从根上杜绝在链接文字/代码/断链 span 里联出**非法嵌套 `<a>`**。

## 多智能体评审修复（`/code-review ultra`，同一变更内）

8 项 actionable findings 全修，3 项低危 noted/skipped：
- `span` 纳入 `_RAW_SKIP_SUBTREE`——断链灰 span 内不再联出指向**另一源**的可点 rawlink
- `_lookup_raw` 按存在性试 `<名>`/`<名>.md`——含内部点 stem 命中、**非 `.md` 资产链接原样保留 href**（不毁 `raw/images/x.png`）
- 去掉 wikilink display 的 `AtomicString`——恢复 `[[页|**别名**]]` 别名内联格式（既有 wikilink 回归）
- 裸路径尾界 `(?![\w\-])` 放行句末 `.`（`raw/x.md.` 仍联链）
- `_raw_name_index` 精确键 + 无冲突小写兜底——大小写敏感盘上同名异写零串台
- markdown 链接保留作者 `title`；`_linkify` 尾段插入改 O(n) 偏移跟踪

## 测试

- `uv run pytest`：**1069 passed, 1 skipped**（case-collision 测试在 macOS 大小写不敏感盘跳过）
- `tests/test_web.py` +16 测试（渲染四写法/标灰/不嵌套/资产保留/大小写/别名格式 + 端到端 `/api/page`）
- 实 uvicorn 端到端冒烟通过

新增 4 条 i18n 键 `raw.{banner,openInTab,loading,openFail}`（中英平价）；CHANGELOG `[Unreleased]` 已记。`.gitignore` 顺带忽略 dev-local `/kbs/`。

🤖 Generated with [Claude Code](https://claude.com/claude-code)