### PR TITLE
feat: Web 翻 auto 后确认 UI 收进单框（恢复钮+安全提示并入确认框，恢复即如实回滚）

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,18 @@
     `link_resolution_index` fold 纪律）——大小写敏感盘上 `raw/Foo.md`/`raw/foo.md` 各按真实名解析、零串台；
     markdown 链接改写保留作者 `title`；`_linkify` 尾段插入改 O(n) 偏移跟踪（去 `list.index` 的 O(n²)）。
 
+### 变更
+
+- **Web 翻 auto 后的确认 UI 收进单框** —— 用户点「本会话起自动放行」（confirm_mode 翻 auto）后，原先
+  「恢复逐次确认」按钮与「本会话已自动放行 ASK 操作（仍只写 wiki/workspace，raw/ 与 AGENTAO.md 仍只读）」
+  安全提示是确认框下方另起的一条独立黄条；现把两者都**并进**「Agent 请求执行操作（请审阅）」确认框内：
+  恢复钮就近放在置灰的「拒绝」钮前，提示文案作为框内一行（`.interaction-automode-inline`）。点「恢复逐次
+  确认」后框内如实回滚——`note.remove()` 撤掉已失真的提示行、去掉「本会话起自动放行」前的 `✓`（移除
+  `.chosen`）、钮后内联「已恢复逐次确认。」。冷启刷新时页面已是 auto（无对应确认框可挂钮）仍走原来的独立
+  黄条带钮路径不变。实现上抽出共享的 `makeRestoreButton()` 工厂（确认框内一处、独立黄条一处共用），
+  `scripts/smoke_p415.py` 同步把定位从独立 `.interaction-automode` 改为框内 `.interaction-automode-inline`。
+  纯前端、零服务端改动；写边界与 `/confirm-mode {ask}` 可逆语义不变。
+
 ## [0.1.16] - 2026-06-24
 
 ### 新增

--- a/guanlan/web/static/app.css
+++ b/guanlan/web/static/app.css
@@ -148,6 +148,7 @@ body {
 .msg.note .interaction-status.inline { margin-top: 0; } /* timeout/stopped：贴在「拒绝」钮后内联，不另起一行 */
 .msg.note .interaction-status.stale { color: #c0392b; }
 .msg.note.interaction-automode { border-color: #e0a800; background: #fff8e1; color: #6b4e00; }
+.msg.note .interaction-automode-inline { margin-top: .5rem; font-size: .74rem; color: #6b4e00; } /* 翻 auto 后并进确认框的安全提示行 */
 
 /* ── 主体：grid（chat │split│ wiki / input 满宽） ──
    右栏宽度由 --wiki-w 驱动（默认 26rem），中间一条可拖动的分隔条改写它；JS 持久化到 localStorage。 */

--- a/guanlan/web/static/chat.js
+++ b/guanlan/web/static/chat.js
@@ -1128,7 +1128,25 @@ function finalizeInteraction(div, decision) {
       if (deny) deny.insertAdjacentElement("afterend", tag);
       else div.appendChild(tag);
     }
-    if (decision === "allow_session") showAutoModeNote(); // 翻 auto：给「恢复逐次确认」一键
+    if (decision === "allow_session") {
+      // 翻 auto：把「恢复逐次确认」一键就近放进本框（置灰的「拒绝」钮前），安全提示文案也并入本框（不另起黄条）。
+      const note = document.createElement("div");
+      note.className = "interaction-automode-inline"; // 「仍只写 wiki/workspace，raw/ 与 AGENTAO.md 仍只读」就近提示
+      note.textContent = t("interaction.autoNote");
+      const restore = makeRestoreButton(div, (b) => {
+        const tag = document.createElement("span");
+        tag.className = "interaction-status inline";
+        tag.textContent = t("interaction.restored"); // 「已恢复逐次确认」贴在钮后内联
+        b.insertAdjacentElement("afterend", tag);
+        note.remove(); // 已恢复逐次确认：撤掉已失真的「已自动放行」提示
+        const sess = div.querySelector(".interaction-btn.allow-session");
+        if (sess) sess.classList.remove("chosen"); // 自动放行已撤销：去掉「本会话起自动放行」前的 ✓
+      });
+      const deny = div.querySelector(".interaction-btn.deny");
+      if (deny) deny.insertAdjacentElement("beforebegin", restore);
+      else div.querySelector(".interaction-actions").appendChild(restore);
+      div.appendChild(note);
+    }
     $("#chat-log").scrollTop = $("#chat-log").scrollHeight;
     return;
   }
@@ -1147,26 +1165,33 @@ function finalizeInteraction(div, decision) {
   $("#chat-log").scrollTop = $("#chat-log").scrollHeight;
 }
 
-// 本会话起自动放行后的提示 + 「恢复逐次确认」（/confirm-mode {ask}）。镜像 CLI 第 2 项的安全版：
-// 仅松「问不问」、姿态仍 workspace-write、层①②③ 不动、可逆（§6）。
+// 「恢复逐次确认」按钮工厂（/confirm-mode {ask}）：点击即置灰自身、POST 成功后回调 onRestored(b) 落反馈。
+// box 仅供失败时 markInteractionStale 归属。镜像 CLI 第 2 项的安全版：仅松「问不问」、姿态仍
+// workspace-write、层①②③ 不动、可逆（§6）。
+function makeRestoreButton(box, onRestored) {
+  const b = document.createElement("button");
+  b.className = "interaction-btn restore";
+  b.textContent = t("interaction.restoreConfirm");
+  b.addEventListener("click", () => {
+    b.disabled = true;
+    interactionPost("/confirm-mode", { confirm_mode: "ask" }, box, () => onRestored(b));
+  });
+  return b;
+}
+
+// 冷启刷新时已是 auto（无对应确认框可挂钮）：单独一条黄色提示带「恢复逐次确认」一键。翻 auto 的当场
+// 走的是 finalizeInteraction——钮与文案都就近并进确认框，不来这里。
 function showAutoModeNote() {
-  addNote((div) => {
+  return addNote((div) => {
     div.classList.add("interaction-automode");
     const p = document.createElement("div");
     p.textContent = t("interaction.autoNote");
     div.appendChild(p);
-    const b = document.createElement("button");
-    b.className = "interaction-btn restore";
-    b.textContent = t("interaction.restoreConfirm");
-    b.addEventListener("click", () => {
-      b.disabled = true;
-      interactionPost("/confirm-mode", { confirm_mode: "ask" }, div, () => {
-        const done = document.createElement("div");
-        done.textContent = t("interaction.restored");
-        div.appendChild(done);
-      });
-    });
-    div.appendChild(b);
+    div.appendChild(makeRestoreButton(div, () => {
+      const done = document.createElement("div");
+      done.textContent = t("interaction.restored");
+      div.appendChild(done);
+    }));
   });
 }
 

--- a/scripts/smoke_p415.py
+++ b/scripts/smoke_p415.py
@@ -264,8 +264,9 @@ class Smoke:
         b1.locator(".interaction-btn.allow-session").click()
         # 新交互：在「本会话起自动放行」钮上打勾（.chosen），不增状态行。
         b1.locator(".interaction-btn.allow-session.chosen").wait_for(state="visible", timeout=8000)
-        # 翻 auto：出现自动放行提示 + 「恢复逐次确认」钮
-        self.page.locator(".interaction-automode").last.wait_for(state="visible", timeout=8000)
+        # 翻 auto：自动放行提示 + 「恢复逐次确认」钮都并进确认框（不再另起黄条）
+        b1.locator(".interaction-automode-inline").wait_for(state="visible", timeout=8000)
+        b1.locator(".interaction-btn.restore").wait_for(state="visible", timeout=8000)
         self.wait_idle()
         # 第二条：auto 下静默放行——不该再弹 confirm 气泡
         before = self.page.locator(".msg.interaction.confirm").count()


### PR DESCRIPTION
## 背景

P4.15 Web 工具确认里，用户点「本会话起自动放行」（confirm_mode 翻 auto）后，原先：
- 「恢复逐次确认」按钮 + 「本会话已自动放行 ASK 操作（仍只写 wiki/workspace，raw/ 与 AGENTAO.md 仍只读）」安全提示，是确认框**下方另起的一条独立黄条**。

按用户反馈，把这些都**收进**「Agent 请求执行操作（请审阅）」确认框内，并让「恢复」后框内如实回滚。

## 变更

- **恢复钮就近放进确认框** —— `insertAdjacentElement("beforebegin", …)` 插到置灰的「拒绝」钮前面，按钮行变为 `允许 · 本会话起自动放行✓ · 恢复逐次确认 · 拒绝`。
- **安全提示并入框内一行** —— 框内追加 `.interaction-automode-inline`（淡琥珀小字，呼应确认框琥珀左边框），不再另起黄条。
- **点「恢复逐次确认」后如实回滚**：
  - `note.remove()` 撤掉已失真的「已自动放行」提示行；
  - 移除 allow-session 钮的 `.chosen` → 去掉「本会话起自动放行」前的 `✓`；
  - 钮后内联「已恢复逐次确认。」。
- **冷启路径不变** —— 页面刷新时已是 auto（无对应确认框可挂钮），仍走原来的独立黄条带钮（line 156 `showAutoModeNote()`）。
- **重构** —— 抽出共享 `makeRestoreButton(box, onRestored)` 工厂，确认框内一处、独立黄条一处共用；删掉一度引入又作废的 `autoModeNoteEl` 句柄。
- **smoke** —— `scripts/smoke_p415.py` 定位从独立 `.interaction-automode` 改为框内 `.interaction-automode-inline` + `.interaction-btn.restore`。

纯前端、**零服务端改动**；写边界与 `/confirm-mode {ask}` 可逆语义不变。

## 测试

- `uv run pytest tests/test_web.py` → 484 passed, 1 skipped（后端未触及）。
- `node --check guanlan/web/static/chat.js` 通过。
- 用户已人工验证 UI 行为。

🤖 Generated with [Claude Code](https://claude.com/claude-code)