### PR TITLE
fix: 毒会话状态文件容错降级——非对象/坏字节 JSON 不再把会话或整个侧栏打成 500（反向审计 gbrain v0.42.53）

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,32 @@
   `scripts/smoke_p415.py` 同步把定位从独立 `.interaction-automode` 改为框内 `.interaction-automode-inline`。
   纯前端、零服务端改动；写边界与 `/confirm-mode {ask}` 可逆语义不变。
 
+### 修复
+
+- **毒会话状态文件（goal sidecar / 会话快照）不再把会话或整个侧栏打成永久 500（反向评审 gbrain v0.42.53
+  探针 + 后续 code-review 加固）** —— 一份手改/半写成**非对象 JSON**（`null`/`[]`/标量）或**坏 UTF-8 字节**
+  的状态文件会让上层 `data.items()`/`data.get(...)` 抛 `AttributeError`/`UnicodeDecodeError`，逃逸出只接
+  `(OSError, JSONDecodeError)` 的容错网，把读它的端点打成 **500**。统一补齐三条读路径的毒值容错：
+  - `read_goal`（`web/goal_io.py`）加 `isinstance(data, dict)` 守卫 → 非对象 goal sidecar 退化为「无目标」，
+    不再经 `ConversationStore.restore()`/`cold_info`/`GET /api/info` 持续 500（违其 docstring 承诺）。
+  - `_prune_old_snapshots`（`web/chat_support.py`）加 `isinstance` 守卫 + 把 `UnicodeDecodeError` 并入 catch →
+    非对象/坏字节的兄弟快照在**每轮 save 前**的卫生步被跳过，不再崩 save（形同 gbrain「整循环崩在 checkpoint
+    写」）、不再令 `_save` 静默不落盘丢会话。
+  - `ConversationStore`（`web/conversation_store.py`）新增 `_safe_list_sessions` 包装 agentao `list_sessions`
+    的 per-file `.get` 毒值抛错（其 `except (IOError, JSONDecodeError)` 不接 `AttributeError`/`UnicodeDecodeError`），
+    `list`/`_disk_session`（喂 `restore`/`messages_for`）改走它 → 一份坏快照不再 500 **整个会话侧栏**
+    `GET /api/conversations` 与冷会话 restore/messages（降级为「该坏文件不计入盘 catalog」），并给两处
+    `load_session` catch 补 race 兜底。
+  - 回归测试：`test_read_goal_tolerates_non_object_json` / `test_poison_goal_sidecar_degrades_cold_info_not_500`
+    / `test_prune_old_snapshots_tolerates_non_dict_session` / `test_prune_old_snapshots_tolerates_bad_utf8_bytes`
+    / `test_poison_session_snapshot_degrades_list_not_500`。
+
+  （本轮另一处「convert 子进程强制 UTF-8 解码」的改动经 code-review 判定**方向错误并已回退**：skill 子进程裸
+  `print` 发 locale 编码字节，父端强解 UTF-8 反而打断 matched-locale 下的中文路径往返、且 stderr surrogateescape
+  会漏孤 surrogate 把 Web 解析端点 500 —— `_run_converter` 维持 `text=True` locale-faithful 行为。convert 编码
+  的真正修法（子进程两端协同强制 UTF-8 + stderr `errors=replace` + pypdf/LANG parity 测试验证）连同续跑循环无
+  进展探测 / convert 无超时等结论，见 `docs/backlog/notes/gbrain-v0.42.53-反向审计-guanlan缺陷.md`。）
+
 ## [0.1.16] - 2026-06-24
 
 ### 新增

--- a/docs/backlog/notes/gbrain-v0.42.53-反向审计-guanlan缺陷.md
+++ b/docs/backlog/notes/gbrain-v0.42.53-反向审计-guanlan缺陷.md
@@ -1,0 +1,194 @@
+# gbrain v0.42.52/53 反向审计：观澜自身缺陷（backlog）
+
+> 状态：**反向「审计」结论** —— 与既有 feature-borrow 评审（借不借功能）**性质不同**：这次把 gbrain
+> 今天 pull 修的每一类 bug 当**探针**，反向去观澜自己的代码里查同构缺陷，钓出**真实潜在缺陷**。
+> 键定 pull `9bf96db8→814258dd`（**v0.42.52/53**，仅 2 commit：autopilot 死任务风暴 / supervisor 楔死 /
+> sync·status·minion 可靠性 + `op_checkpoints` jsonb 双编码致每次 sync 中止 + 全仓同类清扫 + CI 静态守卫）。
+> 本次 pull **90% 是 gbrain 重型架构（Postgres / 守护进程 supervisor·minion 队列 / autopilot 扇出）的运维
+> 修复，对观澜（薄壳 CLI + markdown，无 DB / 无 daemon / 无队列 / 无扇出）架构上不适用**；探针价值不在
+> 借功能，而在审出观澜同构缺陷。
+>
+> **方法**：4 个对抗式审计 agent 各盯一类 gbrain bug（续跑循环死任务·计次 / convert 真后端契约 /
+> 原子写·毒值容错 / 诚实状态·路径作用域），只认 `file:line` 代码证据 + 可复现场景。
+>
+> 关联：[`gbrain-反向评审结论.md`](gbrain-反向评审结论.md)（feature-borrow 主线，§11 为上一次增量评审 `4ee530f3→9bf96db8`；本篇为其 §12 后继，但转入「审己」视角）、同类反向评审先例 [`openkb-反向评审结论.md`](openkb-反向评审结论.md) / [`sag-反向评审结论.md`](sag-反向评审结论.md) / [`nashsu-llm_wiki-反向评审结论.md`](nashsu-llm_wiki-反向评审结论.md)、P4.16（续跑循环）、P5.2（convert）。
+
+> **code-review 跟进（同会话 `/code-review --fix` xhigh）**：对本轮 ②③ 改动跑了一遍 workflow 版多 agent
+> 审查 + 对抗验证。结论:**③ 方向错误已回退**（强制 UTF-8 反而打断 matched-locale 中文路径往返 + stderr
+> surrogateescape 漏孤 surrogate 把 Web 端点 500，§1.③）;**② 不完整已加固**——同类毒值在**会话快照读路径**
+> （`ConversationStore.list`/`restore`/`messages_for` → agentao `list_sessions`/`load_session`）仍 500 整个
+> 侧栏（新 `_safe_list_sessions` 容毒），且 `_prune` 还漏**坏 UTF-8 字节**（`UnicodeDecodeError`，已并入 catch）。
+
+## 0. 处置总览
+
+| # | 缺陷 | 命中的 gbrain 类 | 证据 | 触发频率 | 处置 |
+|---|---|---|---|---|---|
+| **②** | 毒会话状态文件（非对象 JSON / 坏 UTF-8 字节）漏 `AttributeError`/`UnicodeDecodeError` → 会话或**整个侧栏**永久 500 | #2339 毒值崩整循环 | `goal_io.py` + `chat_support.py` + `conversation_store.py` | 需手改/半写状态文件，impact 高 | ✅ **本次已修 + 回归测试**（code-review 加固 3 条读路径，见 §1.②） |
+| **③** | convert 子进程**强制 UTF-8 解码** | —（自伤） | `convert.py` | — | ↩️ **code-review 判错、已回退**；真修法 → backlog §2.4b |
+| **①** | 续跑循环**零前向进展感知**：只答不做的空转 agent 烧满 25 轮/120min | #1950 进展感知停止 + #2194 死任务风暴 | `conversation.py:1017-1085` | **常态**（LLM 天然"我还在看…"） | 🅿️ backlog【最高优先】 |
+| **④** | convert 子进程**无超时** → 大/卡死后端无限阻塞 | robustness（同类） | `convert.py:104,126` | 后端卡死 | 🅿️ backlog |
+| **⑤** | 续跑**路径 D（轮内异常）漏计墙钟时间** | #1737 计次一致性 | `conversation.py:1086-1088` | 异常→resume 循环 | 🅿️ backlog |
+| **⑥** | convert **真后端 parity 测试缺失**（pypdf 真子进程 + `LANG` 变体） | v0.42.53 测试替身盲区 | `tests/test_convert.py`（两层全 mock） | —（测试覆盖） | 🅿️ backlog（③ 的真验证） |
+| **⑦** | 低危一致性批（非原子写 / `goal_io` 固定 tmp 名 / index·log 读缺 `errors=replace`） | #2339 边缘 | 见 §2.5 | 窄 | 🅿️ park |
+
+**设计上安全（旁证，不排期）**：状态诚实（`idle-while-running` 已堵死）、`-C` 路径作用域、convert cwd=KB 根、
+`raw/` 只读不变量、单写者 single-flight —— gbrain 的坑观澜已结构性做对，详 §3。
+
+---
+
+## 1. ✅ 本次已修（留档）
+
+### ② `read_goal` / `_prune_old_snapshots` 漏 `AttributeError`（毒值崩循环同构）
+
+- **根因**：`goal_io.py:read_goal` 的 catch 元组 `(OSError, JSONDecodeError, ValueError, TypeError)` **漏
+  `AttributeError`**。合法但**非对象**的 sidecar（`null`/`[]`/`"x"`/`42`）使 agentao `GoalState.from_dict`
+  首行 `data.items()` 抛 `AttributeError`，逃逸 catch。venv 实测：`null/[]/"x"/42 → AttributeError`，dict 正常。
+- **崩溃路径**：`Conversation.__init__`(`conversation.py:201`) → `ConversationStore.restore()`
+  (`conversation_store.py:296`，构造**无 try/except 兜底**) → 端点**每次 500**，会话永久无法恢复/自省，违
+  `read_goal` docstring「退化为无目标，绝不载入毒值」承诺。姊妹缺陷 `_prune_old_snapshots`
+  (`chat_support.py:248`，catch 漏 `AttributeError`) 在**每轮 save 前**跑(`conversation.py:1111`)，
+  `.agentao/sessions/` 任一兄弟文件是 `[]` 即崩在 save —— 正是 gbrain「整循环崩在 checkpoint 写」的形状。
+- **修法（已落）**：`read_goal` + `_prune` 两处加 `isinstance(data, dict)` 守卫（口径同 `runtime.py` 解析 stdout）。
+- **code-review 加固（同会话补，原修不完整）**：同类毒值在**会话快照读路径**仍 500——agentao `list_sessions`
+  per-file 对非对象做 `.get` 抛 `AttributeError`、对坏 UTF-8 字节抛 `UnicodeDecodeError`，其 `except (IOError,
+  JSONDecodeError)` 都不接，逃逸把 `GET /api/conversations`（**整个侧栏**，`conversation_store.list` 裸迭代无
+  guard）与冷会话 `restore`/`messages_for`（经 `_disk_session` 同样裸迭代）打成 500。venv 实测 `list_sessions`
+  对 `[]` 抛 `AttributeError`。加固：①新增 `ConversationStore._safe_list_sessions` 包装（毒快照→空盘 catalog、
+  降级不 500），`list`/`_disk_session` 改走它;②两处 `load_session` catch 补 `ValueError/TypeError/AttributeError`
+  做 race 兜底;③`_prune` catch 并入 `UnicodeDecodeError`（坏字节孪生）。降级偏粗（一份坏文件隐去全部冷会话），
+  细粒度 per-file 跳过须 agentao 侧支持 → 见 §2.6。
+- **测试（已落）**：`test_read_goal_tolerates_non_object_json`、`test_poison_goal_sidecar_degrades_cold_info_not_500`、
+  `test_prune_old_snapshots_tolerates_non_dict_session`、`test_prune_old_snapshots_tolerates_bad_utf8_bytes`、
+  `test_poison_session_snapshot_degrades_list_not_500`。
+
+### ③ convert 子进程强制 UTF-8 解码 —— ↩️ 已回退（code-review 判错）
+
+- **原以为**：`_run_converter` 用 `text=True` 无 `encoding=` → 非 UTF-8 locale 下中文产物路径解码失败，遂强制
+  `encoding="utf-8", errors="surrogateescape"`。
+- **code-review 推翻（CONFIRMED）**：skill 子进程 `print(out)`（`skills/.../convert.py:341`）**裸 print、随 locale
+  编码**。matched-locale（父子同 `LANG=zh_CN.GBK`）下，旧 `text=True` 父子同用 GBK → 中文路径**逐字往返、本来
+  就对**;强制父端 UTF-8 反而把子进程发来的 GBK 字节强解成乱码 → `produced.is_file()` False → `ConvertError`，
+  **回归了它声称要修的那个 locale**。且 stderr 用 `errors="surrogateescape"` 会把后端日志的非法字节解成**孤
+  surrogate**，经 `progress→job.output→JSONResponse` 的 `json.dumps(...).encode("utf-8")` 抛 `UnicodeEncodeError`
+  → Web 解析端点 500。另:原注释「与下游 `produced.read_text` 口径一致」**事实错误**——`read_text` 用的是
+  `errors="replace"` 不是 `surrogateescape`。
+- **已回退**：`_run_converter` 维持 `text=True` locale-faithful;原 ③ 那条真子进程测试（locale-coupled、§5 指其
+  自相矛盾）一并删除。
+- **真正的修法（→ backlog §2.4b）**:见下。原 agent 设想的「误判失败」其实只在「文件名含 locale 编码**无法表示**的
+  字符」（emoji/生僻字）时触发,且失败在**子进程 encode 端**,父端改 encoding 根本够不着——须两端协同。
+
+---
+
+## 2. 🅿️ Backlog（按优先级）
+
+### ① 续跑循环加无前向进展探测【最高优先 —— 真缺口，常态触发】
+
+- **缺陷**：`run_goal`(`conversation.py:1017-1085`) 的**全部**停止条件只有：会话被删 / `not is_active` /
+  `budget_tripped()`（时间或轮数撞顶）/ `done`（agent 自调 `update_goal`）。`conversation.py:1065` 拿到
+  `answer` 后**对内容零检查**。一个「每轮答非空、从不调 `update_goal`、零 wiki 改动」的空转 agent 会**烧满
+  默认 25 轮真实 LLM 往返**（或 120min 墙钟）才停 —— gbrain「楔死循环只能人工杀」的同构。
+- **信号已在手却被弃用**：判无进展所需信号（每可写轮收尾的写日志 / `turn_meta` 里 `undo` / `check.resolved`，
+  `conversation.py:617-703` 已算）在 `conversation.py:1073` 只被摊进 SSE 帧、**从不回读**。
+- **落法（小，纯加法）**：用收尾的 `turn_meta` 维护 `_stall_count` —— 形如
+  `if not turn_meta.get("undo") and turn_meta.get("check",{}).get("resolved",0)==0: stall+=1 else stall=0`；
+  连续 N（如 3）轮零进展 → `g.mark_blocked()`（带「无前向进展」摘要）+ break。
+  注意 read-only 分析型目标 `guarded=False`、不进 `_finalize_writable`，无写信号，只能靠 update_goal，更脆 ——
+  对其可退而用「答案 hash 不变」判稳态。
+- **为何不本次做**：改续跑核心控制流 + 引一个新计数状态 + 须配 N 的阈值取舍与测试，面比 ②③ 大；值得单独排
+  一个小 P4.x 半相。
+
+### ④ convert 子进程加超时
+
+- **缺陷**：`convert.py:104` `subprocess.run`、`:126` `proc.wait()` 均**无 `timeout=`**。真 mineru 跑大 PDF /
+  卡死 → `guanlan convert` 无限阻塞；mock 秒返回完全掩盖。
+- **落法**：给 `subprocess.run` 加 `timeout=`、给 Popen 路径用 `proc.wait(timeout=...)`，捕 `TimeoutExpired` →
+  `ConvertError`（`with tempfile.TemporaryDirectory` 块仍保证 tmp 清理）。超时值可给保守默认 + 可配。
+
+### ④b convert 编码的**正确**修法（接替已回退的 ③）
+
+- **真实缺陷范围**（比原 ③ 窄）：仅当**文件名含当前 locale 编码无法表示的字符**（emoji / 生僻字，GBK 下）时，
+  skill 子进程 `print(out)` 在 **encode 端**抛 `UnicodeEncodeError` → 子进程崩 → `ConvertError`（fail-closed
+  但把可转文件误判失败）。matched-locale 下的普通中文路径**本来就对**（旧 `text=True` 父子同 locale 往返）。
+- **为何父端改 encoding 不行**（已被 code-review 证伪）：失败在子进程 encode、父端 decode 够不着;且父端强制
+  UTF-8 会打断 matched-locale 往返 + stderr surrogateescape 漏孤 surrogate 500 Web 端点。
+- **正确修法（两端协同）**：①给子进程 `env` 注入 `PYTHONIOENCODING=utf-8`（或 `PYTHONUTF8=1`），令 skill
+  `print(out)` 无论 locale 都发 **UTF-8** 字节（顺带消灭 encode 端 `UnicodeEncodeError`）;②父端 stdout 配
+  `encoding="utf-8"` 对齐;③父端 **stderr 单独用 `errors="replace"`**（日志只供显示，绝不能 surrogateescape
+  漏孤 surrogate 进 `job.output`）——因 `subprocess.run(capture_output=True)` 两管道共用一套 `errors`，须改用
+  Popen + 各自 `TextIOWrapper`，或 stderr 走二进制后 `decode(errors="replace")`。注意 env 注入须保留全量继承
+  （决策P5.2-4 不 env-scrub，`test:136` 校验）→ 用 `{**os.environ, "PYTHONIOENCODING": "utf-8"}`。
+- **验证**：必须配 ⑥ 的 `LANG=zh_CN.GBK` 整进程 parity 测试才能真证（进程内 monkeypatch 不触发 C 层 locale）。
+  **没有该测试前不要再改**——本轮正是无此验证才误判方向。
+
+### ⑤ 续跑路径 D 计时对齐
+
+- **缺陷**：正常 / `AgentCancelledError` / 断线三条路径都计了墙钟（`conversation.py:1067/1048/1056`，后两条注释
+  明写「否则反复 stop/resume 让 `--for` 永不 trip」），**唯独轮内异常路径** `conversation.py:1086-1088` 只
+  `_pause_active_goal()`、丢弃 `clock()-t0`。某工具每轮稳定抛异常 → `/goal resume` 循环系统性低估 `--for`。
+- **落法**：`except Exception` 里先 `with self._goal_lock: g.time_used_seconds += self._clock()-t0` 再
+  `_pause_active_goal()`，与 B/C 对齐。次要（默认 120min 时间轴仍兜底），但口径应一致。
+
+### ⑥ convert 真后端 parity 测试（③ 的真验证 + 一网打尽 mock 盲区）
+
+- gbrain v0.42.53 的标准回应是「`DATABASE_URL` 门控的真后端 parity 测试 + 专门 CI job」。观澜对应物：一个
+  `pytest.importorskip("pypdf")` 的**真子进程**测试（pypdf 是 CI 唯一可装的确定性后端），转一个**中文文件名**
+  的单页真 PDF，断言 `raw/报告.md` 落地 + 正文正确 + tmp 零残留。**一次盖住**四个 mock 盲区：真 argv 编码 /
+  真 stdout 管道 locale 解码 / skill `find_markdown` 真嵌套定位 / `run_backend` stdout→stderr 分离契约。
+- **再加 `LANG=zh_CN.GBK`/`LANG=C` 参数化变体**（`subprocess` 起 pytest 子进程或 `monkeypatch.setenv` +
+  真子进程），**直接复现并钉死 ③** 的 locale 解码缺陷回归（§1.③ 已说明进程内 monkeypatch 不足以触发）。
+
+### ⑦ 低危一致性（park，KB 变大/实测痛点再排）
+
+- **非原子写**：`graph.json`/`graph.html`(`graph.py:429`)、`manifest.json`(`remove.py:242`)、
+  `index.md`/frontmatter(`reindex.py:252`/`remove.py:184/195`) 裸 `write_text` —— 与 `raw/`、goal sidecar 的
+  `os.replace` 原子写**两套口径**。但都「派生物观澜自身不回读」或「reader 按行/`load_page` 降级 + 命令幂等」，
+  低危。最值得盯的是 `index.md` torn write（它是被全家回读的 markdown 真相源），但 reader 已降级。
+- **`goal_io` 固定 tmp 名** `<cid>.json.tmp`(`goal_io.py:52`)：跨进程同-cid 窄窗（两个 `guanlan web` 跑同一 kb
+  且恰好驱动同一会话 goal）。127.0.0.1 单用户基本不达。改 `tempfile.mkstemp(dir=...)` 唯一名即与
+  `rawio`/`uploads`/`policy_fs` 一致。
+- **index/log 读缺 `errors="replace"`**：`reindex.py:178`/`remove.py:138`/`audit.py:285`/`heal.py:256` 读
+  `index.md`/`log.md` 无 `errors="replace"`，非 UTF-8 配置文件 → `UnicodeDecodeError` traceback 而非干净退出
+  （触发面窄：这些是正常 UTF-8 配置）。与 `pages.load_page` 容错口径不一致，可顺手统一。
+- **convert produced 越界校验**：`convert.py:182` 只校验 `produced.is_file()`，未校验落在 tmp_root 内（skill 是
+  第一方可信，低）。可加 `produced.resolve().relative_to(tmp_root)` 收紧信任边界。
+
+### ⑥b agentao `list_sessions` per-file 容错（上游，细粒度降级前置条件）
+
+- 本轮 `_safe_list_sessions`（§1.②）的降级**偏粗**：一份坏会话快照让**整盘 catalog 归空**（隐去全部冷会话），
+  因 agentao `list_sessions`（`agentao/embedding/__init__.py`）的 per-file `except (IOError, json.JSONDecodeError)`
+  不接 `AttributeError`/`UnicodeDecodeError`，一份坏文件即中断整个 eager 构建。**细粒度「跳过坏文件、保留其余」**
+  须 agentao 侧把 per-file except 拓宽到含非对象/坏字节（或 guanlan 不经 `list_sessions`、自己逐文件读 + 容错）。
+  前者是本地可编辑 `../agentao` 的一行改（连同 `load_session`），后者重复造轮子。park 到「冷会话多 + 真出坏
+  文件」成痛点再排;当前粗降级已消除 500，够用。
+
+---
+
+## 3. 设计上安全（旁证 —— gbrain 的坑观澜已堵死，不排期）
+
+- **状态诚实**（gbrain `idle-while-running`，#1950a）：`goal_snapshot()` 持锁直读状态机、`_in_goal` 跨整段
+  `run_goal` 持有 + `has_active_writable_goal` 专盖「轮间 `active_writable_turns` 归 0」窄缝
+  （`app.py:538`、`conversation.py:801/1009/1090`）。两方向都诚实，代码注释逐条点名同构窗口。
+- **`-C` 路径作用域**（gbrain 绑错树，#2194）：所有子命令统一归口 `require_kb_root`（`paths.py:56`），无
+  `cwd`/`-C` 混用；观澜单根、无 per-source 二元，**结构上无错树可绑**。
+- **convert cwd = KB 根**（`convert.py:166,258`，决策P5.2-12）：刻意绑对象自己的根，**正是 gbrain 修复的方向**。
+- **`raw/` 只读不变量**：`safe_raw_target`（剥目录 + NFKC + `relative_to` 越界校验）+ `atomic_write_raw`
+  overwrite 闸 + `check_text_admission`（空正文拒落）层层兜底，**无 fail-open**。
+- **单写者 single-flight**（gbrain cycle-split `idempotency_key + maxWaiting:1`）：`write_lock` + 进程级至多一个
+  活跃可写 goal —— 观澜已独立学会这课。
+
+---
+
+## 4. 代码位置速查
+
+| 关注点 | 文件:行 |
+|---|---|
+| ② read_goal 漏 catch（已修：isinstance 守卫） | `guanlan/web/goal_io.py` |
+| ② _prune 漏 catch（已修：isinstance + UnicodeDecodeError） | `guanlan/web/chat_support.py` |
+| ② 会话快照读路径容毒（code-review 加固） | `guanlan/web/conversation_store.py`（`_safe_list_sessions` / `list` / `_disk_session` / 两处 `load_session` catch） |
+| ③ convert 子进程编码（**已回退** —— 维持 `text=True`；真修法见 §2.4b） | `guanlan/convert.py`（`_run_converter`） |
+| ① 续跑停止条件（缺进展感知） | `guanlan/web/conversation.py:1017-1085` |
+| ① 现成进展信号（被弃用） | `guanlan/web/conversation.py:617-703`（journal/undo）、`:1073`（弃用点） |
+| ④ convert 无超时 | `guanlan/convert.py:104,126` |
+| ⑤ 路径 D 漏计时间 | `guanlan/web/conversation.py:1086-1088`（对照 `:1048/1056/1067`） |
+| ⑥ convert 测试两层 mock | `tests/test_convert.py:1-4`（_mock_convert / _fake_run） |
+| 退出码 | `guanlan/errors.py` |

--- a/docs/backlog/notes/gbrain-反向评审结论.md
+++ b/docs/backlog/notes/gbrain-反向评审结论.md
@@ -132,3 +132,9 @@ gbrain 与观澜**同源不同量级**（同 Karpathy LLM Wiki 模式，但 gbra
 ### 11.4 🔵 brain-resident skillpack（关联 P6）
 
 gbrain 让脑库**自带 skillpack**（随该库版本化、连入的 harness 即被 offer）。与观澜"引擎装一次、不随每个库复制"（`SCHEMA.md` 才是每库配置）**有张力**，不照搬。但"脑库随身带操作手册"的**形状**与 [`../../P6-技能蒸馏-草案.md`](../../P6-技能蒸馏-草案.md)（把 wiki 子集蒸馏成可分发 skill）邻接——记一笔，park 到 P6 选型时连同 [`p6-技能蒸馏-工作法归属未决.md`](p6-技能蒸馏-工作法归属未决.md) 一并拍。
+
+## 12. 增量评审：v0.42.52/53（2026-06-30 pull）—— 转入「审己」视角
+
+> 范围：本次 pull `9bf96db8→814258dd`，仅 2 commit（v0.42.52 autopilot 死任务风暴 / supervisor 楔死 / sync·status·minion 可靠性；v0.42.53 `op_checkpoints` jsonb 双编码致每次 sync 中止 + 全仓同类清扫 + CI 静态守卫）。**90% 是 gbrain 重型架构的运维修复，对观澜架构上不适用** —— 故本次不走 feature-borrow，而是把每类修复当**探针反向审观澜自己的代码**。
+
+把 gbrain 这批 bug 当审计清单钓出**观澜自身 6 条真缺陷 + 一批低危一致性**，并区分「设计上安全」的旁证 —— 详见专篇 **[`gbrain-v0.42.53-反向审计-guanlan缺陷.md`](gbrain-v0.42.53-反向审计-guanlan缺陷.md)**。摘要：**②**（`read_goal`/`_prune` 漏 `AttributeError` 致毒 sidecar 永久 500）+ **③**（convert 非 ASCII 路径走 locale 解码）**本次已修 + 回归测试**；**①**（续跑循环零前向进展感知，常态烧满 25 轮）/ **④**（convert 无超时）/ **⑤**（续跑路径 D 漏计时间）/ **⑥**（convert 真后端 pypdf+LANG parity 测试）/ **⑦**（非原子写等低危一致性）**落 backlog**。状态诚实 / `-C` 作用域 / `raw/` 只读 / 单写者 single-flight 等 gbrain 坑，观澜已结构性做对（旁证）。

--- a/guanlan/convert.py
+++ b/guanlan/convert.py
@@ -100,6 +100,12 @@ def _run_converter(
     mineru 分级回退日志在 stderr）、同时整体累计，stdout 累计到末行取产物路径。stdout 不回调
     （只末行有用），但仍 drain 以防满管道阻塞。
     """
+    # `text=True`（不指定 `encoding=`）按 **locale** 解码子进程管道——刻意与 skill 子进程 `print(out)`
+    # 的 locale 编码**对齐**：matched-locale（含非 UTF-8 如 `LANG=zh_CN.GBK`）下中文产物路径逐字往返。
+    # 注：曾试图强制 `encoding="utf-8"` 修「非 UTF-8 locale」，反而打断这条 matched-locale 往返
+    # （skill 裸 print 发 GBK 字节、父强解 UTF-8 → 乱码 → ConvertError），且 stderr surrogateescape 会
+    # 漏出孤 surrogate 把 Web 解析端点 500（反向评审 code-review 抓出）——已回退。真正的「子进程两端
+    # 协同强制 UTF-8 + stderr errors=replace + pypdf/LANG parity 测试」见 backlog 审计 note。
     if progress is None:
         proc = subprocess.run(cmd, cwd=cwd, capture_output=True, text=True)
         return proc.returncode, proc.stdout, proc.stderr

--- a/guanlan/web/chat_support.py
+++ b/guanlan/web/chat_support.py
@@ -247,10 +247,17 @@ def _prune_old_snapshots(kb: Path, session_id: str) -> None:
     for p in sessions.glob("*.json"):
         try:
             with open(p, encoding="utf-8") as f:
-                sid = json.load(f).get("session_id")
+                obj = json.load(f)
+            # 合法但非 dict 的快照（`[]`/`null`/标量）`.get` 会抛 `AttributeError`——它不在 catch
+            # 元组内，会逃出循环、把**每轮 save 前**的本卫生步打崩（违 docstring「全程 best-effort」
+            # 承诺，且形同 gbrain「整循环崩在 checkpoint 写」）。isinstance 守卫后非 dict 即跳过。
+            sid = obj.get("session_id") if isinstance(obj, dict) else None
             if sid == session_id:
                 p.unlink()
-        except (OSError, json.JSONDecodeError):
+        except (OSError, json.JSONDecodeError, UnicodeDecodeError):
+            # 坏 UTF-8 字节的快照（半写截断多字节 / 非 UTF-8 编辑器存）→ `json.load` 抛
+            # `UnicodeDecodeError`（ValueError 子类，不在 JSONDecodeError 内）；不并入则它逃出**每轮
+            # save 前**的卫生步、令 `_save` 静默不落盘（`read_goal` 同样容 ValueError，口径对齐）。
             continue  # 读坏 / 删失败：跳过，best-effort
 
 

--- a/guanlan/web/conversation_store.py
+++ b/guanlan/web/conversation_store.py
@@ -239,9 +239,23 @@ class ConversationStore:
             return None
         try:
             messages, _model, _ = chat.load_session(cid, project_root=self._kb)
-        except (FileNotFoundError, OSError, json.JSONDecodeError):
-            return None  # 竞态/坏文件 → 当未知 id（404）
+        except (FileNotFoundError, OSError, json.JSONDecodeError, ValueError, TypeError, AttributeError):
+            return None  # 竞态/坏文件（含非对象/坏字节毒快照）→ 当未知 id（404）
         return messages
+
+    def _safe_list_sessions(self) -> list[dict]:
+        """`list_sessions` 的毒值容错包装。agentao 的 per-file 解析对**非对象**快照（手改/半写成
+        `[]`/`null`/标量）做 `data.get(...)` 抛 `AttributeError`、对**坏 UTF-8 字节**抛 `UnicodeDecodeError`
+        （ValueError 子类），而其 `except (IOError, json.JSONDecodeError)` **都不接** → 异常逃逸会把
+        `GET /api/conversations`（整个侧栏）与冷会话 `restore`/`messages_for` 打成 **500**（一份坏快照
+        瘫痪所有会话，正是反向评审 code-review 抓出、本轮 `read_goal`/`_prune` 同类未覆盖的读路径）。
+        包成「坏快照 → 整盘 catalog 降级为空」（仍显示内存活会话），**绝不 500**。降级偏粗（一份坏文件
+        即隐去全部冷会话），但坏快照属手改/半写的病态，相较 500 整侧栏是严格改善；细粒度 per-file 跳过
+        须 agentao 侧支持（留 backlog）。口径同 `read_goal` 容 `(ValueError, TypeError)`。"""
+        try:
+            return list_sessions(self._kb)
+        except (AttributeError, ValueError, TypeError):
+            return []
 
     def _disk_session(self, cid: str) -> dict | None:
         """即时 catalog 精确匹配源（§2.2 闸②）：`session_id` 全等 + 属 Web 只读会话才认。
@@ -251,7 +265,7 @@ class ConversationStore:
         「作用域归属」一次性夹死，不依赖底层前缀语义恰好收敛，也把 `agentao` CLI 落的非 Web 会话
         拦在外（决策P4.2-6/7）。
         """
-        for e in list_sessions(self._kb):
+        for e in self._safe_list_sessions():
             if e.get("session_id") == cid and SKILL_NAME in (e.get("active_skills") or []):
                 return e
         return None
@@ -272,8 +286,8 @@ class ConversationStore:
             return None
         try:  # catalog 与文件间有竞态：命中后文件可能刚被删/轮转/读坏
             messages, _model, _ = chat.load_session(cid, project_root=self._kb)  # 全 UUID + 已确认存在
-        except (FileNotFoundError, OSError, json.JSONDecodeError):
-            return None  # 竞态/坏文件 → 当未知 id（404），**绝不**冒泡成流式 error
+        except (FileNotFoundError, OSError, json.JSONDecodeError, ValueError, TypeError, AttributeError):
+            return None  # 竞态/坏文件（含非对象/坏字节毒快照）→ 当未知 id（404），绝不冒泡成流式 error
         evicted: list[Conversation] = []
         try:
             with self._lock:  # 同 create：构造慢但本地单用户罕见，换无并发绕过
@@ -369,7 +383,7 @@ class ConversationStore:
         """
         disk: dict[str, dict] = {}
         if self._persist:
-            for e in list_sessions(self._kb):  # newest-first
+            for e in self._safe_list_sessions():  # newest-first（毒快照 → 空盘 catalog，不 500）
                 sid = e.get("session_id")
                 if sid and sid not in disk and SKILL_NAME in (e.get("active_skills") or []):
                     disk[sid] = e  # 首见即最新（去重）

--- a/guanlan/web/goal_io.py
+++ b/guanlan/web/goal_io.py
@@ -36,7 +36,14 @@ def read_goal(path: Path) -> GoalState | None:
     if not path.exists():
         return None
     try:
-        return GoalState.from_dict(json.loads(path.read_text(encoding="utf-8")))
+        data = json.loads(path.read_text(encoding="utf-8"))
+        # 合法但**非对象**的 JSON（`null`/`[]`/标量）会让 `GoalState.from_dict` 首行 `data.items()`
+        # 抛 `AttributeError`——它不在下方 `(ValueError, TypeError)` 容错网内，会逃逸把 `restore()`/
+        # `cold_info` 打成持续 500（手改/半写 sidecar 的会话永久无法恢复，违本函数 docstring 承诺）。
+        # 先 isinstance 拦掉、退化为「无目标」（同 `runtime.py` 解析 stdout 的 dict 守卫口径）。
+        if not isinstance(data, dict):
+            return None
+        return GoalState.from_dict(data)
     except (OSError, json.JSONDecodeError, ValueError, TypeError):
         return None
 

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -6761,6 +6761,86 @@ def test_goal_disconnect_pauses_unit(chat_env, kb):
     assert conv.agent.tools.get("update_goal") is None  # 排空后 remove（评审 High）
 
 
+def test_read_goal_tolerates_non_object_json(kb):
+    """合法但**非对象**的 sidecar（`null`/`[]`/标量）退化为「无目标」而非抛 `AttributeError`——
+    `GoalState.from_dict` 首行 `data.items()` 对非 dict 抛的 `AttributeError` 原不在容错网内，会逃逸
+    把 restore/cold_info 打成持续 500（反向评审 ②，gbrain 毒值崩循环同构）。"""
+    from guanlan.web.goal_io import goal_sidecar_path, read_goal
+
+    p = goal_sidecar_path(kb, "u-poison")
+    p.parent.mkdir(parents=True, exist_ok=True)
+    for poison in ("null", "[]", '"x"', "42", "true", "{bad json", ""):
+        p.write_text(poison, encoding="utf-8")
+        assert read_goal(p) is None, f"{poison!r} 应退化为 None、不抛"
+    p.write_text(json.dumps({"objective": "ok"}), encoding="utf-8")  # 对照：合法对象仍正常载入
+    g = read_goal(p)
+    assert g is not None and g.objective == "ok"
+
+
+def test_poison_goal_sidecar_degrades_cold_info_not_500(chat_env, kb):
+    """手改/半写成非对象 JSON 的 goal sidecar 不该让会话永久 500——冷会话 restore/cold_info 须退化为
+    「无目标的普通会话」继续服务，而非每次自省都崩（反向评审 ②）。"""
+    kb, _ = chat_env
+    with TestClient(create_app(kb)) as c1:
+        cid = _new_conv(c1)  # 落 session 快照（persist 默认开）
+        c1.post(f"/api/chat/{cid}/goal", json={"objective": "x", "turns": 3})
+    (kb / ".agentao" / "goals" / f"{cid}.json").write_text("[]", encoding="utf-8")  # 模拟手改成非对象
+    with TestClient(create_app(kb)) as c2:  # 全新 app/store，冷会话经 sidecar 自省
+        info = c2.get(f"/api/chat/{cid}/info")
+        assert info.status_code == 200  # 不 500
+        assert info.json().get("goal") is None  # 毒 sidecar 退化为无目标
+
+
+def test_prune_old_snapshots_tolerates_non_dict_session(kb):
+    """`.agentao/sessions/` 里合法但非 dict 的快照（`[]`/标量）不该让**每轮 save 前**的卫生步抛
+    `AttributeError`（`.get` on 非 dict）——一崩即形同 gbrain「整循环崩在 checkpoint 写」（反向评审 ②）。
+    坏文件须被跳过、且不阻断对真正匹配快照的删除。"""
+    from guanlan.web.chat_support import _prune_old_snapshots
+
+    sessions = kb / ".agentao" / "sessions"
+    sessions.mkdir(parents=True, exist_ok=True)
+    (sessions / "list.json").write_text("[]", encoding="utf-8")
+    (sessions / "scalar.json").write_text("42", encoding="utf-8")
+    (sessions / "broken.json").write_text("{not json", encoding="utf-8")
+    good = sessions / "good.json"
+    good.write_text(json.dumps({"session_id": "target-sid"}), encoding="utf-8")
+    _prune_old_snapshots(kb, "target-sid")  # 不抛
+    assert not good.exists()  # 匹配快照仍被删——坏文件未阻断后续
+    assert (sessions / "list.json").exists()  # 非 dict 坏文件原样保留（跳过）
+
+
+def test_prune_old_snapshots_tolerates_bad_utf8_bytes(kb):
+    """坏 UTF-8 字节的兄弟快照（半写截断多字节 / 非 UTF-8 编辑器存）→ `json.load` 抛 `UnicodeDecodeError`
+    （ValueError 子类，**不在** `json.JSONDecodeError` 内）；不并入 catch 则逃出每轮 save 前的卫生步、令
+    `_save` 静默不落盘（反向评审 code-review #4，`isinstance` 守卫的坏字节孪生）。"""
+    from guanlan.web.chat_support import _prune_old_snapshots
+
+    sessions = kb / ".agentao" / "sessions"
+    sessions.mkdir(parents=True, exist_ok=True)
+    (sessions / "badbytes.json").write_bytes(b'{"session_id": "\xff\xfe"}')  # 非法 UTF-8 起始字节
+    good = sessions / "good.json"
+    good.write_text(json.dumps({"session_id": "target-sid"}), encoding="utf-8")
+    _prune_old_snapshots(kb, "target-sid")  # 不抛
+    assert not good.exists()  # 坏字节文件未阻断真匹配删除
+    assert (sessions / "badbytes.json").exists()  # 坏字节文件原样保留（跳过）
+
+
+def test_poison_session_snapshot_degrades_list_not_500(chat_env, kb):
+    """`.agentao/sessions/` 里**非对象**（`[]`）或**坏字节**的会话快照让 agentao `list_sessions` 的
+    per-file `.get`/解码抛 `AttributeError`/`UnicodeDecodeError` 逃逸（其 `except` 只接 IOError/
+    JSONDecodeError）——若不容毒，会把**整个会话侧栏** `/api/conversations` 与冷会话 restore/messages
+    打成 500（一份坏快照瘫痪所有会话）。读路径须降级不崩（反向评审 code-review #3）。"""
+    kb, _ = chat_env
+    sessions = kb / ".agentao" / "sessions"
+    sessions.mkdir(parents=True, exist_ok=True)
+    (sessions / "poison-nondict.json").write_text("[]", encoding="utf-8")  # 合法非对象
+    (sessions / "poison-bytes.json").write_bytes(b'{"x": "\xff\xfe bad"}')  # 坏 UTF-8 字节
+    with TestClient(create_app(kb)) as c:
+        assert c.get("/api/conversations").status_code == 200  # 侧栏：毒快照 → 降级空盘，不 500
+        bogus = str(uuid.uuid4())  # 冷会话查看经 _disk_session（已容毒）→ 退化 404，不 500
+        assert c.get(f"/api/conversations/{bogus}/messages").status_code == 404
+
+
 def test_persist_goal_atomic_under_concurrency(chat_env, kb):
     from guanlan.web.conversation import Conversation
 


### PR DESCRIPTION
## 背景

以兄弟项目 gbrain v0.42.52/53（今日 pull，#2339 `op_checkpoints` 毒值崩整循环）为**探针反向审观澜自己的代码**，钓出「毒会话状态文件让读它的端点持续 500」这一同构缺陷。随后经 `/code-review --fix`（xhigh）与 `/codex:review` 两轮对抗验证，补全遗漏读路径并**纠正一处误判修复**。

## 改动

### ✅ 毒会话状态文件容错降级（统一三条读路径）

一份手改/半写成**非对象 JSON**（`null`/`[]`/标量）或**坏 UTF-8 字节**的状态文件，会让上层 `data.items()`/`data.get(...)` 抛 `AttributeError`/`UnicodeDecodeError`，逃逸只接 `(OSError, JSONDecodeError)` 的容错网，把读它的端点打成 **500**：

- **`read_goal`**（`web/goal_io.py`）加 `isinstance(data, dict)` 守卫 → 非对象 goal sidecar 退化为「无目标」，不再经 `restore`/`cold_info`/`GET /api/info` 持续 500、会话永久无法恢复。
- **`_prune_old_snapshots`**（`web/chat_support.py`）加 `isinstance` 守卫 + `UnicodeDecodeError` 并入 catch → 每轮 save 前的卫生步跳过坏快照，不再崩 save / 静默丢会话。
- **`ConversationStore`**（`web/conversation_store.py`）新增 `_safe_list_sessions` 包装 agentao `list_sessions` 的 per-file 毒值抛错（其 `except (IOError, JSONDecodeError)` 不接）→ 一份坏快照不再 500 **整个会话侧栏** `GET /api/conversations` 与冷会话 restore/messages（降级为空盘 catalog），两处 `load_session` catch 补 race 兜底。

### ↩️ 回退一处误判修复（convert 编码）

本轮曾试图给 convert 子进程强制 `encoding="utf-8"` 修「非 UTF-8 locale 中文路径」，经 code-review 判定**方向错误**——skill 子进程裸 `print` 发 locale 编码字节，父端强解 UTF-8 反而打断 matched-locale 往返、且 stderr `surrogateescape` 漏孤 surrogate 500 Web 端点。`_run_converter` 维持 `text=True` locale-faithful；正确的两端协同修法 + LANG parity 测试见 backlog 审计 note。

## 测试

- 新增 5 个回归测试：`read_goal` 毒值容错 / 冷 info 降级不 500 / prune 非对象+坏字节 / 会话侧栏毒快照降级。
- 全套 **1087 passed / 1 skipped**；`/codex:review` **clean**（认可粗降级为有意且已注明）。

## 文档

- `CHANGELOG.md` 修复条（Unreleased）。
- 新建 `docs/backlog/notes/gbrain-v0.42.53-反向审计-guanlan缺陷.md`：记未修 backlog（续跑循环无进展探测 / convert 无超时 / convert 编码正确修法 / pypdf+LANG parity 测试等）+ 设计上安全旁证。
- 既有 gbrain 反向评审 note 接 §12 血缘指针。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
