### PR TITLE
chore: 进入开发态 0.1.17 → 0.1.18.dev0

### DIFF
--- a/guanlan/__init__.py
+++ b/guanlan/__init__.py
@@ -4,4 +4,4 @@ P1 交付 `guanlan init`（确定性生成最小模板）。ingest / query 等 L
 由 `guanlan-wiki` skill 驱动 Agentao 完成；本包只做编排与确定性门禁。
 """
 
-__version__ = "0.1.17"
+__version__ = "0.1.18.dev0"


### PR DESCRIPTION
v0.1.17 已定版发布到 PyPI（`guanlan-wiki 0.1.17`，wheel + sdist 已上架、隔离 venv 实跑 `guanlan --version` = 0.1.17 验证通过）。按既有发布收尾套路（对应上一轮 #19），把版本号推进开发态。

### 改动（1 行）
- `guanlan/__init__.py`：`__version__` `0.1.17` → `0.1.18.dev0`（单一版本源）

CHANGELOG 不动 —— `[Unreleased]` 段等下一个变更落地时再加（与 #19 一致）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)