### PR TITLE
feat: ingest 撞名守卫 + query/Web 检索收敛提示（llm_wiki v0.6 反向评审两项立即动作）

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,31 @@
 本项目所有显著变更记录于此。格式参考 [Keep a Changelog](https://keepachangelog.com/zh-CN/1.1.0/)，
 版本号遵循 [语义化版本](https://semver.org/lang/zh-CN/)。版本号单一来源为 `guanlan/__init__.py`。
 
+## [未发布]
+
+### 新增
+
+- **ingest 摄入前挡「同一 source 页 slug 撞名」（源自 nashsu/llm_wiki v0.6 反向评审 §2.2，见 [`docs/backlog/notes/llm_wiki-反向评审-v0.6.md`](docs/backlog/notes/llm_wiki-反向评审-v0.6.md)）**
+  —— source 摘要页由 `rawio.find_source_page` 按 **`raw_slug(stem)`**（=页身份归口）定位，故两篇 raw
+  `.md` 只要 `raw_slug(stem)` 相同（`a/report.md` 与 `b/report.md`、`annual report.md` 与
+  `annual-report.md`、`.report.md` 与 `report.md`）就会误关联到**同一张** `wiki/sources/<slug>.md`——
+  一张压另一张、`raw_digest` 只认得一个版本（此前源命名仅约定 kebab、无子目录消歧防线）。`ingest.py`
+  新增确定性 `_reject_source_slug_collision` 预检：摄入前扫 `raw/` 下**其余 `.md`**，凡 `raw_slug(stem)`
+  与目标相同即 `EXIT_USAGE` 拒绝、列出冲突路径、要求改名。**零-LLM、只堵不重构**——复用既有 `raw_slug`
+  （不新增 slug 方案/哈希/迁移），**只比 `.md`**（唯一会被 ingest 建 source 页者）故不误伤 convert 的
+  `report.pdf`+`report.md` 同源对。经 xhigh code-review 从初版「按 basename 判」收正为「按 `raw_slug`
+  判」（basename 太窄，漏 `annual report`↔`annual-report` 等异名同 slug 的真撞页）。残留：`find_source_page`
+  的 `.`→`-` 回退（`1.报告`↔`1-报告`）键不同、不在此拦（窄边角，不复刻 rawio 折叠逻辑以免漂移）。测试见
+  `tests/test_ingest.py`（撞页拒绝 / slug-fold 折叠拒绝 / pdf+md 同源对放行）。
+
+### 优化
+
+- **query / Web 续跑提示补「检索收敛红线」（源自 v0.6 反向评审 §2.1）** —— CLI `query.QUERY_PROMPT` 与
+  Web 目标续跑 `web/conversation._continuation_prompt`（P4.16 循环，正是易空转处）各补一句「**不要重复等价
+  检索；证据足够即回答**」，压重复召回 / 空转。**纯提示词、零代码逻辑改动**——刻意不写进 `AGENTAO.md`
+  （会波及 ingest 等所有工作流，太宽）、不引 agentao 侧预算参数（保薄壳 + 循环真相源在 agentao）。测试见
+  `tests/test_query.py`（CLI 提示含红线）/ `tests/test_web.py`（Web 续跑提示含红线）。
+
 ## [0.1.17] - 2026-07-01
 
 ### 新增

--- a/docs/backlog/notes/llm_wiki-反向评审-v0.6.md
+++ b/docs/backlog/notes/llm_wiki-反向评审-v0.6.md
@@ -1,0 +1,39 @@
+# nashsu/llm_wiki 反向评审 v0.6（增量·backlog）
+
+> 状态：**反向评审结论，非排期项**。承 [`nashsu-llm_wiki-反向评审结论.md`](nashsu-llm_wiki-反向评审结论.md)（至 v0.5.4=`c03c6be`），本篇键定 **2026-07-11 pull**（`c03c6be→9b71ade`，v0.5.4→**v0.6.3**，102 文件 +22365/-4995）。**不改变现状，只借形状、不借实现。**
+>
+> **评审修订（2026-07-11，收敛）**：初稿把 §2 的 4 信号关联评分定为"强借 + 候选 P3.12"，经评审**降级**——权重无观澜语料 precision 支撑（**未知类型默认亲和 0.5 → 几乎任意页对得正分**，配"全库打分"即 O(N²)、大量弱建议；**"零基建"≠低成本低噪声**），改为 **park + 一个离线小实验**；"图谱洞察（惊喜连接 / 知识缺口）"与现有拓扑 health/lint 重叠，**删除落地建议**。本篇收敛为 **两项立即小动作（§2）+ 一项仅观察（§3）+ 其余不做（§4）**。
+>
+> **进展更新（实现后回填，2026-07-11）**：§2 **两项立即动作均已实现**（见 [`CHANGELOG.md`](../../../CHANGELOG.md) 未发布段）——§2.1 query/Web 收敛提示 = `query.QUERY_PROMPT` + `web/conversation._continuation_prompt` 各补「不要重复等价检索；证据足够即回答」；§2.2 ingest 撞名守卫 = `ingest._reject_source_slug_collision`，经 xhigh code-review 从「按 basename 判」**收正为按 `raw_slug(stem)`（页身份归口）判、只比 `.md`**（review §1「basename 太窄」漏 `annual report`↔`annual-report` 等 slug-fold 撞页；只比 `.md` 避 convert `pdf`+`md` 误伤）。§3 仅观察、§4 不做 **均未动**。
+>
+> 关联：[`nashsu-llm_wiki-反向评审结论.md`](nashsu-llm_wiki-反向评审结论.md)、[`../../P2.1-摄入写入纪律.md`](../../P2.1-摄入写入纪律.md)（决策P2.1-4：绝不让代码改写正文）、[`../../P5.0-检索层.md`](../../P5.0-检索层.md)（E1 边界 + 实证②）、[`../../P3.11-断链最近页建议.md`](../../P3.11-断链最近页建议.md)（"断链找近似页"，与 §1-A **不同轴**）、[`cjk-retrieval-enhancements.md`](cjk-retrieval-enhancements.md)、[`gbrain-反向评审结论.md`](gbrain-反向评审结论.md)。
+
+## 0. 一句话
+
+本次 pull 主线：Rust 后端 chat agent 重写 + 智能/混合检索（keyword+vector+graph 融合）+ 4 信号图关联 + agent 循环收敛护栏 + 源生命周期硬化 + 页面历史/守卫撤销。过观澜红线后，**真正的新缺口只有三个**（§1），对应 **两项立即小动作 + 一项仅观察**；4 信号加权、图谱洞察、向量/RRF 全部**不排期**（§4）。
+
+## 1. 新增缺口（真实的）
+
+- **A. 未互链的相关页面对**：观澜 `lint` 只为**断链**找近似页（P3.11），对**两张都已存在、共享同一批 `sources:` 却互不 `[[链接]]`** 的页零建议。这是本次唯一站得住的新缺口——但 llm_wiki 那套 4 信号加权（源重叠×4 / 直接链接×3 / Adamic-Adar×1.5 / 类型亲和×1，未知默认 0.5）**证据不足、噪声不明**，观澜**只认最硬的一个信号：共享 source**。→ §3 仅观察。
+- **B. query 循环无收敛纪律**：CLI `QUERY_PROMPT` 与 Web chat 提示都没说"别重复等价检索 / 证据足够即答"，可能空转、重复召回。→ §2.1。
+- **C. source basename 撞名误关联风险**：`rawio.find_source_page` 只按 `Path(rel).stem`（**纯 basename**）定位摘要页，而 `provenance.raw_digest` 用**完整相对路径**——`raw/a/report.pdf` 与 `raw/b/report.pdf` 存在**误关联到同一 `wiki/sources/report.md` 的风险**。**是否真覆盖取决于 Agent 实际写页行为，不能仅由 wrapper 代码断定**（故只堵、不重构）。→ §2.2。
+
+## 2. 最小动作（立即做，两项）
+
+1. **query / Web 各加一句收敛提示**：在 **CLI `QUERY_PROMPT`** 与 **Web chat 提示** 各补一句"**不要重复等价检索；证据足够即回答。**"。**不写进 `AGENTAO.md`**（会波及 ingest 等所有工作流，太宽）、**不调查 agentao 预算参数**、不升级成全局宪法。零成本、两处各一行。
+2. **ingest 前拒绝 raw 子目录重复 basename**：摄入前检查 `raw/` 下是否已有同 basename 的其他文件；有则**明确拒绝并要求改名**。**不引**新 slug 算法 / 哈希后缀 / collision 迁移 / 约定重写——只堵 §1-C 那个最小故障面。
+
+## 3. 仅观察（不排期）
+
+**共享 source 的未互链页对——离线小实验**：用**倒排表**枚举"共享 `sources:` 的页面对"，输出 **top-N 做人工抽样**看 precision。**暂不**接 `lint`/MCP/reader，**不引** Adamic-Adar / 类型矩阵 / 社区信号。先证伪"共享 source 这一个信号是否够强"——**有明确 precision 后**，再决定是否评分、是否产品化（届时才谈 P3.12）。
+
+## 4. 不做什么（park / 别借，附理由）
+
+- **4 信号加权（类型亲和 / Adamic-Adar / 全库打分）**：park，待 §3 precision。未知类型默认 0.5 会让几乎任意页对得正分，O(N²) 噪声大——照抄权重前须先有观澜语料样本。
+- **图谱洞察（惊喜连接 / 知识缺口）**：其"孤立 / 稀疏社区 / 桥节点"与现有拓扑 health/lint（`graphstats` P3.5/P3.6）**大量重叠**，非新缺口，**删落地建议**。
+- **混合向量 / RRF / 图一跳融合**：= **E1**，别现动。可抄常数已录备 E1 选型：RRF `k=60`、图混入占最终窗 15–30%、分块 1000/overlap 200、维度动态存 LanceDB、距离转分 `1/(1+d)`。
+- **enrich-wikilinks 应用半**（LLM 出 `{term,target}` JSON → **代码把 `[[]]` 落进正文**）：撞 决策P2.1-4，别借（前篇 §6 同结论）；其确定性半还只护 frontmatter + 已有 `[[]]`、代码块/标题避让全靠 LLM 不提。
+- **持久文件历史 + 守卫式撤销**：别借——**当前产品范围不提供应用内版本历史，依赖用户自行使用 git；收益不足以引入持久状态**（`.llm-wiki/*.json` 持久派生物与"markdown 唯一真相"张力）。**订正**：`gate` 快照 / `.trash/` / git 与通用页面历史·undo **并不等价**，git 也非强制前提——这里是"**范围外**"，不是"已覆盖"。
+- **源自动监视 → 移动迁移**：观澜是批处理 CLI、**无常驻 daemon**，N/A；其删除决策（sole source → 删页）已由 `remove`（P3.9）等价覆盖。
+- **Louvain 社区 / 源指纹漂移检测**：观澜已有——`graphstats.detect_communities`（手写确定性 Louvain，且另做 Tarjan 桥/割点健康度；llm_wiki 本次才补社区、且只用于检索加权）/ `provenance.raw_digest` + `audit`（P3.7，早于本次 pull）。
+- **in-page UI / 页面链接面板 / Mermaid / 生成物预览 / Rust runtime 重写 / linux webkit**：桌面 UI 与架构，观澜是 CLI + 只读 Web + agentao 子进程，面不重叠。

--- a/docs/backlog/notes/nashsu-llm_wiki-反向评审结论.md
+++ b/docs/backlog/notes/nashsu-llm_wiki-反向评审结论.md
@@ -5,6 +5,8 @@
 > **特殊性**：nashsu/llm_wiki 是观澜**最直接的架构孪生**（同 Karpathy 模式、同"本地 markdown + 增量 ingest"路线），历史上被**逐条散引**进多篇 P 文档（**P2.1** 整篇即对它的反向评审——re-ingest 合并不覆盖 / 正文不被改写 / 70% 缩水守卫）。本笔记是**首篇合并结论**，键定在 **2026-06-29 这次 pull**（`dda8768→c03c6be`，至 `v0.5.4`，151 文件 +12385/-1510），覆盖整个 delta。
 >
 > **进展更新（实现后回填）**：§2 lint 断链建议 = **[`../../P3.11-断链最近页建议.md`](../../P3.11-断链最近页建议.md)**（规格，已过两轮评审、可排期，落地清单见其 §9）；§3 finding 持久抑制 = **[`finding-持久抑制-未排期.md`](finding-持久抑制-未排期.md)**（backlog，未排期）。余条未排。
+>
+> **增量评审（2026-07-11 pull，`c03c6be→9b71ade`，v0.5.4→v0.6.3，102 文件 +22365/-4995）**：另篇 **[`llm_wiki-反向评审-v0.6.md`](llm_wiki-反向评审-v0.6.md)**（经评审收敛）。**两项立即小动作已实现**（回填见该篇进展更新 + [`CHANGELOG.md`](../../../CHANGELOG.md) 未发布段）——query/Web 各加一句收敛提示 + ingest 撞名守卫（`_reject_source_slug_collision`，经 code-review 收正为按 `raw_slug` 判）；**一项仅观察**——"共享 source 的未互链页对"离线小样本验 precision（暂不 P3.12）；4 信号加权 / 图谱洞察（惊喜连接·知识缺口，与拓扑 lint 重叠）/ 向量-RRF 全部**不排期**。**同样只借形状、不借实现**。
 > 关联：[`broken-link-handling-survey.md`](broken-link-handling-survey.md)（断链四参考实现总览，§2 的旧 llm_wiki 数据点在此）、[`../../P2.1-摄入写入纪律.md`](../../P2.1-摄入写入纪律.md)（既有 llm_wiki 反向评审）、[`openkb-反向评审结论.md`](openkb-反向评审结论.md) / [`gbrain-反向评审结论.md`](gbrain-反向评审结论.md) / [`sag-反向评审结论.md`](sag-反向评审结论.md)（同类先例）、DESIGN §3（参考实现对比）/ §8。
 
 ## 0. 一句话 / 为什么记

--- a/guanlan/ingest.py
+++ b/guanlan/ingest.py
@@ -13,7 +13,7 @@ from .errors import EXIT_OK, EXIT_USAGE, GuanlanError
 from .gate import run_guarded_write
 from .paths import require_kb_root
 from .provenance import compute_raw_digest, format_digest_value, stamp_raw_digest
-from .rawio import find_source_page
+from .rawio import find_source_page, raw_slug
 from .runtime import AgentRunner
 
 # 薄 prompt：真正步骤在 skill。{rel} = 相对 raw/ 的 posix 路径。
@@ -55,6 +55,41 @@ def _resolve_raw_target(root: Path, target: str) -> Path:
     return tpath
 
 
+def _reject_source_slug_collision(raw_dir: Path, tpath: Path) -> None:
+    """摄入前挡「`raw/` 里多篇 `.md` 会落到同一张 wiki/sources 摘要页」（见 docs/backlog/notes/llm_wiki-反向评审-v0.6.md §1-C/§2.2）。
+
+    source 摘要页由 `find_source_page` 按 **`raw_slug(stem)`**（=页身份归口）定位，故凡此键相同的两篇
+    raw `.md`——`a/report.md` 与 `b/report.md`、`annual report.md` 与 `annual-report.md`、
+    `.report.md` 与 `report.md` ——都会误关联到**同一张**页：一张压另一张、`raw_digest` 只认得一个
+    版本（review §1「按 basename 判太窄」）。**只堵不重构**：不新增 slug 方案/哈希/迁移，直接复用既有
+    `raw_slug` 算键。**只比 `.md`**（唯一会被 ingest 建 source 页者），故不误伤 convert 的
+    `report.pdf`+`report.md` 同源对。残留：`find_source_page` 的 `.`→`-` 回退（`1.报告`↔`1-报告`）
+    键不同、不在此拦，属窄边角，留文档不追（不复刻 rawio 折叠逻辑以免漂移）。
+    """
+    target_slug = raw_slug(tpath.stem)
+    if not target_slug:
+        return
+    dups = [
+        p
+        for p in raw_dir.rglob("*")
+        if p.suffix.lower() == ".md"
+        and raw_slug(p.stem) == target_slug
+        and p.is_file()
+        and p.resolve() != tpath
+    ]
+    if not dups:
+        return
+    listing = "\n".join(
+        f"  - raw/{p.relative_to(raw_dir).as_posix()}" for p in [tpath, *dups]
+    )
+    raise GuanlanError(
+        f"raw/ 下多篇 `.md` 的 source 页 slug 都是 `{target_slug}`，摄入会撞进同一张 "
+        f"wiki/sources/{target_slug}.md：\n{listing}\n"
+        "请把其中之一改名（source 页 slug 需全库唯一）再 ingest。",
+        exit_code=EXIT_USAGE,
+    )
+
+
 def run_ingest(
     target: str,
     *,
@@ -66,11 +101,13 @@ def run_ingest(
     try:
         kb = require_kb_root(root, writable=True)
         tpath = _resolve_raw_target(kb, target)
+        raw_dir = (kb / "raw").resolve()  # 单算一次：guard 与 rel 共用（review §cleanup）。
+        _reject_source_slug_collision(raw_dir, tpath)
     except GuanlanError as exc:
         print(exc, file=sys.stderr)
         return exc.exit_code
 
-    rel = tpath.relative_to((kb / "raw").resolve()).as_posix()
+    rel = tpath.relative_to(raw_dir).as_posix()
     # 开场提示（仅交互式终端，stderr 不污染 stdout 信封/管道）：摄入经 Agentao 跑 LLM，
     # 可能耗时数分钟且全程静默——配合 runtime 的心跳，让用户确认不是卡死（A+ 心跳方案）。
     if sys.stderr.isatty():

--- a/guanlan/query.py
+++ b/guanlan/query.py
@@ -21,6 +21,7 @@ QUERY_PROMPT = (
     "请按 `guanlan-wiki` skill 的 query 工作流回答：{question}。"
     "先用**可用的 search 入口**（宿主 `guanlan_search` 工具 / `guanlan search \"<关键词>\"` CLI）召回候选页"
     "（确定性整页 BM25 召回，CJK 走 2-gram、别名已纳入匹配面），读这些候选页 + `wiki/index.md` 综合；"
+    "**不要重复等价检索；证据足够即回答。**"
     "都不可用或空手而回时再扫相关目录或请我补关键词；"
     "综合出**带 `[[页]]` 引用**的答案；无可靠来源时明说、不编造。"
     "**默认只读，不要写 `wiki/`。**"

--- a/guanlan/web/conversation.py
+++ b/guanlan/web/conversation.py
@@ -75,7 +75,7 @@ def _continuation_prompt(objective: str) -> str:
         "and explain what you need. Otherwise keep going — do not stop merely to ask "
         "whether to continue.\n\n"
         "观澜语境：优先用 guanlan_search 召回已有页面、维护 [[wikilink]] 交叉链接、"
-        "遵 `## ⚠️ 矛盾与存疑` 约定标注存疑。"
+        "遵 `## ⚠️ 矛盾与存疑` 约定标注存疑；不要重复等价检索，证据足够即回答。"
     )
 
 

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -143,6 +143,46 @@ def test_ingest_missing_file_usage(kb: Path):
     assert rc == EXIT_USAGE
 
 
+def test_ingest_rejects_source_slug_collision(kb: Path, capsys):
+    """raw/ 子目录里两篇 `.md` 落到同一 source 页 slug → 摄入前确定性拒绝，不跑 agent。"""
+    (kb / "raw" / "a").mkdir()
+    (kb / "raw" / "b").mkdir()
+    (kb / "raw" / "a" / "report.md").write_text("甲\n", encoding="utf-8")
+    (kb / "raw" / "b" / "report.md").write_text("乙\n", encoding="utf-8")
+
+    def boom(root: Path):  # agent 不应被调用
+        raise AssertionError("撞页应在跑 agent 前被拒绝")
+
+    rc = run_ingest("raw/a/report.md", root=kb, runner=make_runner(boom))
+    assert rc == EXIT_USAGE
+    err = capsys.readouterr().err
+    assert "report" in err and "raw/a/report.md" in err and "raw/b/report.md" in err
+
+
+def test_ingest_rejects_slug_fold_collision(kb: Path, capsys):
+    """异 basename 但 `raw_slug` 相同（空格↔连字符）仍会撞同一张页 → 也须拒（review §1：按 basename 判太窄）。"""
+    (kb / "raw" / "a").mkdir()
+    (kb / "raw" / "b").mkdir()
+    (kb / "raw" / "a" / "annual report.md").write_text("甲\n", encoding="utf-8")
+    (kb / "raw" / "b" / "annual-report.md").write_text("乙\n", encoding="utf-8")
+
+    rc = run_ingest("raw/a/annual report.md", root=kb, runner=make_runner(None))
+    assert rc == EXIT_USAGE
+    assert "annual-report" in capsys.readouterr().err
+
+
+def test_ingest_same_stem_different_ext_not_rejected(kb: Path):
+    """convert 同源对 `report.pdf`+`report.md`（slug 同、但只 `.md` 参与判）不误伤：`.md` 仍可摄入。"""
+    (kb / "raw" / "report.pdf").write_text("源 PDF\n", encoding="utf-8")
+    (kb / "raw" / "report.md").write_text("转换后的 md\n", encoding="utf-8")
+
+    def action(root: Path):
+        write_page(root, "wiki/sources/report.md", type="source", sources='["report"]')
+
+    rc = run_ingest("raw/report.md", root=kb, runner=make_runner(action))
+    assert rc == EXIT_OK
+
+
 def test_ingest_not_a_kb_usage(tmp_path: Path):
     rc = run_ingest("raw/x.md", root=tmp_path, runner=make_runner(None))
     assert rc == EXIT_USAGE

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -13,6 +13,16 @@ from guanlan.errors import (
 from guanlan.query import run_query
 
 
+# --- 召回收敛红线（llm_wiki v0.6 反向评审 §2.1）---
+
+
+def test_query_prompt_has_convergence_rule():
+    """CLI query 提示含收敛红线：别重复等价检索、证据足够即答。"""
+    from guanlan.query import QUERY_PROMPT
+
+    assert "不要重复等价检索" in QUERY_PROMPT
+
+
 # --- 默认只读路径 ---
 
 

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -7129,3 +7129,10 @@ def test_delete_during_goal_run_no_resurrect(chat_client, kb):
         release.set()
         t.join(timeout=5)
     assert not side.exists()  # goal 循环未 resurrect 已删 sidecar
+
+
+def test_continuation_prompt_has_convergence_rule():
+    """Web 续跑提示（P4.16）的观澜语境含收敛红线：别重复等价检索、证据足够即答（llm_wiki v0.6 §2.1）。"""
+    from guanlan.web.conversation import _continuation_prompt
+
+    assert "不要重复等价检索" in _continuation_prompt("某目标")


### PR DESCRIPTION
## 背景

nashsu/llm_wiki v0.6 反向评审（`docs/backlog/notes/llm_wiki-反向评审-v0.6.md`）经评审收敛出**两项立即动作**，本 PR 落地二者 + xhigh code-review 修复。

## 改动

### 1. ingest 撞名守卫（新增，零-LLM）
source 摘要页由 `find_source_page` 按 `raw_slug(stem)`（页身份归口）定位——两篇 raw `.md` 只要 `raw_slug(stem)` 相同（`a/report.md`↔`b/report.md`、`annual report.md`↔`annual-report.md`、`.report.md`↔`report.md`）就会误关联到**同一张** `wiki/sources/<slug>.md`，一张压另一张、`raw_digest` 只认得一个版本。

新增确定性 `_reject_source_slug_collision`：摄入前扫 `raw/` 下其余 `.md`，撞页即 `EXIT_USAGE` 拒绝、列冲突路径、要求改名。**复用既有 `raw_slug`**（不新增 slug 方案/哈希/迁移），**只比 `.md`**（唯一会建 source 页者）故不误伤 convert 的 `report.pdf`+`report.md` 同源对。

> xhigh code-review 修复：初版「按 basename 判」太窄（漏异名同 slug 的真撞页），收正为「按 `raw_slug` 判」；并 hoist `(kb/raw).resolve()` 消三次重算。review 另标的两项（同名旁支即拒 = 按 spec 的 eager 拒绝、需 provenance 才能收窄；rglob 全树遍历 = 已被 `snapshot_raw` 同量级遍历覆盖）**按理由 skip**，详见评审记录。

### 2. query / Web 检索收敛提示（优化，纯提示词）
CLI `query.QUERY_PROMPT` 与 Web 续跑 `web/conversation._continuation_prompt`（P4.16 循环，易空转处）各补一句「**不要重复等价检索；证据足够即回答**」，压重复召回/空转。刻意**不写进 `AGENTAO.md`**（会波及 ingest 等所有工作流，太宽）、不引 agentao 侧预算参数（保薄壳、循环真相源在 agentao）。

## 测试

- `tests/test_ingest.py`：撞页拒绝 / slug-fold 折叠拒绝 / pdf+md 同源对放行。
- `tests/test_query.py` / `tests/test_web.py`：各断言收敛红线在 CLI/Web 提示里。
- 全量 `uv run pytest` → **1116 passed, 1 skipped**。

## 文档

CHANGELOG 未发布段 2 条 + 回填 v0.6 反向评审note 进展更新 + 前篇前向指针。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
