### PR TITLE
fix: ingest 撞名守卫按 code-review #2 收敛——合法重摄所有权豁免

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,10 +15,15 @@
   新增确定性 `_reject_source_slug_collision` 预检：摄入前扫 `raw/` 下**其余 `.md`**，凡 `raw_slug(stem)`
   与目标相同即 `EXIT_USAGE` 拒绝、列出冲突路径、要求改名。**零-LLM、只堵不重构**——复用既有 `raw_slug`
   （不新增 slug 方案/哈希/迁移），**只比 `.md`**（唯一会被 ingest 建 source 页者）故不误伤 convert 的
-  `report.pdf`+`report.md` 同源对。经 xhigh code-review 从初版「按 basename 判」收正为「按 `raw_slug`
-  判」（basename 太窄，漏 `annual report`↔`annual-report` 等异名同 slug 的真撞页）。残留：`find_source_page`
-  的 `.`→`-` 回退（`1.报告`↔`1-报告`）键不同、不在此拦（窄边角，不复刻 rawio 折叠逻辑以免漂移）。测试见
-  `tests/test_ingest.py`（撞页拒绝 / slug-fold 折叠拒绝 / pdf+md 同源对放行）。
+  `report.pdf`+`report.md` 同源对。经 xhigh code-review 三轮收敛：① 从初版「按 basename 判」收正为「按
+  `raw_slug` 判」（basename 太窄，漏 `annual report`↔`annual-report` 等异名同 slug 的真撞页）；② **合法重摄
+  豁免**——目标页已存在且其 `raw_digest` 确证归属**本文件**时放行（`_target_page_owned_by`，复用
+  `provenance.parse_digest_value` 归口），使「属主页长期维护、同 slug 旁支只是未摄草稿」时重摄不再假阳被挡；
+  真撞（拿**非属主**旁支覆盖属主页）改在**摄入那个旁支时**当场拒，安全性不减；③ 每次 ingest 全量 `rglob`
+  一遍 `raw/` 是**已接受代价**（`run_guarded_write` 的 `gate.snapshot_raw` 本就同量级遍历 `raw/`、还带哈希，
+  故此遍历同阶更轻）。残留：`find_source_page` 的 `.`→`-` 回退（`1.报告`↔`1-报告`）键不同、不在此拦（窄边角，
+  不复刻 rawio 折叠逻辑以免漂移）。测试见 `tests/test_ingest.py`（撞页拒绝 / slug-fold 折叠拒绝 / pdf+md 同源
+  对放行 / 属主重摄放行 / 非属主覆盖拒绝）。
 
 ### 优化
 

--- a/docs/backlog/notes/llm_wiki-反向评审-v0.6.md
+++ b/docs/backlog/notes/llm_wiki-反向评审-v0.6.md
@@ -4,7 +4,7 @@
 >
 > **评审修订（2026-07-11，收敛）**：初稿把 §2 的 4 信号关联评分定为"强借 + 候选 P3.12"，经评审**降级**——权重无观澜语料 precision 支撑（**未知类型默认亲和 0.5 → 几乎任意页对得正分**，配"全库打分"即 O(N²)、大量弱建议；**"零基建"≠低成本低噪声**），改为 **park + 一个离线小实验**；"图谱洞察（惊喜连接 / 知识缺口）"与现有拓扑 health/lint 重叠，**删除落地建议**。本篇收敛为 **两项立即小动作（§2）+ 一项仅观察（§3）+ 其余不做（§4）**。
 >
-> **进展更新（实现后回填，2026-07-11）**：§2 **两项立即动作均已实现**（见 [`CHANGELOG.md`](../../../CHANGELOG.md) 未发布段）——§2.1 query/Web 收敛提示 = `query.QUERY_PROMPT` + `web/conversation._continuation_prompt` 各补「不要重复等价检索；证据足够即回答」；§2.2 ingest 撞名守卫 = `ingest._reject_source_slug_collision`，经 xhigh code-review 从「按 basename 判」**收正为按 `raw_slug(stem)`（页身份归口）判、只比 `.md`**（review §1「basename 太窄」漏 `annual report`↔`annual-report` 等 slug-fold 撞页；只比 `.md` 避 convert `pdf`+`md` 误伤）。§3 仅观察、§4 不做 **均未动**。
+> **进展更新（实现后回填，2026-07-11）**：§2 **两项立即动作均已实现**（见 [`CHANGELOG.md`](../../../CHANGELOG.md) 未发布段）——§2.1 query/Web 收敛提示 = `query.QUERY_PROMPT` + `web/conversation._continuation_prompt` 各补「不要重复等价检索；证据足够即回答」；§2.2 ingest 撞名守卫 = `ingest._reject_source_slug_collision`，经 xhigh code-review 三轮收敛：① 从「按 basename 判」**收正为按 `raw_slug(stem)`（页身份归口）判、只比 `.md`**（review §1「basename 太窄」漏 `annual report`↔`annual-report` 等 slug-fold 撞页；只比 `.md` 避 convert `pdf`+`md` 误伤）；② **合法重摄豁免**（review §2）——目标页 `raw_digest` 确证归属本文件时放行（`_target_page_owned_by`），真撞改在摄入非属主旁支时当场拒，消假阳；③ 全树 `rglob` 为**已接受代价**（review §3，`gate.snapshot_raw` 本就同量级遍历 `raw/`）。§3 仅观察、§4 不做 **均未动**。
 >
 > 关联：[`nashsu-llm_wiki-反向评审结论.md`](nashsu-llm_wiki-反向评审结论.md)、[`../../P2.1-摄入写入纪律.md`](../../P2.1-摄入写入纪律.md)（决策P2.1-4：绝不让代码改写正文）、[`../../P5.0-检索层.md`](../../P5.0-检索层.md)（E1 边界 + 实证②）、[`../../P3.11-断链最近页建议.md`](../../P3.11-断链最近页建议.md)（"断链找近似页"，与 §1-A **不同轴**）、[`cjk-retrieval-enhancements.md`](cjk-retrieval-enhancements.md)、[`gbrain-反向评审结论.md`](gbrain-反向评审结论.md)。
 

--- a/guanlan/ingest.py
+++ b/guanlan/ingest.py
@@ -11,8 +11,15 @@ from pathlib import Path
 
 from .errors import EXIT_OK, EXIT_USAGE, GuanlanError
 from .gate import run_guarded_write
+from .pages import load_page
 from .paths import require_kb_root
-from .provenance import compute_raw_digest, format_digest_value, stamp_raw_digest
+from .provenance import (
+    RAW_DIGEST_KEY,
+    compute_raw_digest,
+    format_digest_value,
+    parse_digest_value,
+    stamp_raw_digest,
+)
 from .rawio import find_source_page, raw_slug
 from .runtime import AgentRunner
 
@@ -55,7 +62,32 @@ def _resolve_raw_target(root: Path, target: str) -> Path:
     return tpath
 
 
-def _reject_source_slug_collision(raw_dir: Path, tpath: Path) -> None:
+def _target_page_owned_by(sources_dir: Path, tpath: Path, raw_dir: Path) -> bool:
+    """目标 source 页是否**已确证归属**正被摄入的这个 raw 文件（=合法重摄，可豁免撞名拒绝）。
+
+    仅当：源页存在（`find_source_page` 同 `_stamp_source_digest` 的定位归口）+ frontmatter 可解析出
+    `raw_digest` + 其 raw 相对路径 == 本次 `tpath`（review §2 所有权判定）时返回 True。页不存在 / 无或坏
+    `raw_digest`（未 stamp / 手写页 / stamp 曾失败）/ 指纹指向**别的** raw 文件 → False：**宁保守拒**
+    （所有权未确证时不放行，绝不因一个未 stamp 的同 slug 页而放任另一个 raw 覆盖它）。
+    """
+    page = find_source_page(sources_dir, tpath.stem)
+    if page is None:
+        return False
+    meta, _body = load_page(page)  # 容错档：坏/缺 frontmatter → meta=None
+    if meta is None:
+        return False
+    parsed = parse_digest_value(meta.get(RAW_DIGEST_KEY))
+    if parsed is None:
+        return False
+    owner_raw_rel, _sha = parsed  # 形如 "raw/a/summary.md"
+    try:
+        rel = tpath.relative_to(raw_dir).as_posix()
+    except ValueError:
+        return False
+    return owner_raw_rel == f"raw/{rel}"
+
+
+def _reject_source_slug_collision(raw_dir: Path, tpath: Path, sources_dir: Path) -> None:
     """摄入前挡「`raw/` 里多篇 `.md` 会落到同一张 wiki/sources 摘要页」（见 docs/backlog/notes/llm_wiki-反向评审-v0.6.md §1-C/§2.2）。
 
     source 摘要页由 `find_source_page` 按 **`raw_slug(stem)`**（=页身份归口）定位，故凡此键相同的两篇
@@ -65,6 +97,13 @@ def _reject_source_slug_collision(raw_dir: Path, tpath: Path) -> None:
     `raw_slug` 算键。**只比 `.md`**（唯一会被 ingest 建 source 页者），故不误伤 convert 的
     `report.pdf`+`report.md` 同源对。残留：`find_source_page` 的 `.`→`-` 回退（`1.报告`↔`1-报告`）
     键不同、不在此拦，属窄边角，留文档不追（不复刻 rawio 折叠逻辑以免漂移）。
+
+    **合法重摄豁免（review §2）**：目标页已存在且 `raw_digest` 确证归属**本文件**时放行——重摄既有源页
+    是常规操作，同 slug 旁支不是当前属主，不该挡它；真撞（拿一个**非属主**旁支去覆盖属主页）会在**摄入
+    那个旁支时**（`_target_page_owned_by` 判否）当场被拒，安全性不减、假阳大降。
+
+    **性能取舍（review §3，已接受）**：每次 ingest 全量 `rglob` 一遍 `raw/`；`run_guarded_write` 里的
+    `gate.snapshot_raw` 本就同量级遍历 `raw/`（还带哈希），故本遍历是同阶、更轻的附加成本，不另优化。
     """
     target_slug = raw_slug(tpath.stem)
     if not target_slug:
@@ -79,6 +118,8 @@ def _reject_source_slug_collision(raw_dir: Path, tpath: Path) -> None:
     ]
     if not dups:
         return
+    if _target_page_owned_by(sources_dir, tpath, raw_dir):
+        return  # 合法重摄既有属主页 → 放行（review §2）
     listing = "\n".join(
         f"  - raw/{p.relative_to(raw_dir).as_posix()}" for p in [tpath, *dups]
     )
@@ -102,7 +143,7 @@ def run_ingest(
         kb = require_kb_root(root, writable=True)
         tpath = _resolve_raw_target(kb, target)
         raw_dir = (kb / "raw").resolve()  # 单算一次：guard 与 rel 共用（review §cleanup）。
-        _reject_source_slug_collision(raw_dir, tpath)
+        _reject_source_slug_collision(raw_dir, tpath, kb / "wiki" / "sources")
     except GuanlanError as exc:
         print(exc, file=sys.stderr)
         return exc.exit_code

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -12,6 +12,11 @@ from guanlan.errors import (
     EXIT_USAGE,
 )
 from guanlan.ingest import run_ingest
+from guanlan.provenance import (
+    compute_raw_digest,
+    format_digest_value,
+    stamp_raw_digest,
+)
 
 
 def _put_raw(kb: Path, name="doc.md") -> str:
@@ -181,6 +186,45 @@ def test_ingest_same_stem_different_ext_not_rejected(kb: Path):
 
     rc = run_ingest("raw/report.md", root=kb, runner=make_runner(action))
     assert rc == EXIT_OK
+
+
+def _seed_owned_summary(kb: Path) -> Path:
+    """建 raw/2024/summary.md（属主）+ raw/2025/summary.md（同 slug 旁支草稿）+
+    既有 wiki/sources/summary.md，其 raw_digest 指向 raw/2024/summary.md（模拟先前摄入）。返回属主 raw。"""
+    (kb / "raw" / "2024").mkdir()
+    (kb / "raw" / "2025").mkdir()
+    owner = kb / "raw" / "2024" / "summary.md"
+    owner.write_text("2024 摘要\n", encoding="utf-8")
+    (kb / "raw" / "2025" / "summary.md").write_text("2025 草稿（未摄）\n", encoding="utf-8")
+    write_page(kb, "wiki/sources/summary.md", type="source", sources='["summary"]')
+    assert stamp_raw_digest(
+        kb / "wiki" / "sources" / "summary.md",
+        format_digest_value("raw/2024/summary.md", compute_raw_digest(owner)),
+    )
+    return owner
+
+
+def test_ingest_reingest_owner_not_blocked_by_sibling(kb: Path):
+    """合法重摄：既有属主页在（raw_digest 指向本文件），同 slug 旁支存在也放行（review §2 所有权豁免）。"""
+    _seed_owned_summary(kb)
+
+    def action(root: Path):  # 重摄：更新既有属主页
+        write_page(root, "wiki/sources/summary.md", type="source", sources='["summary"]')
+
+    rc = run_ingest("raw/2024/summary.md", root=kb, runner=make_runner(action))
+    assert rc == EXIT_OK
+
+
+def test_ingest_non_owner_into_owned_slug_rejected(kb: Path, capsys):
+    """真撞：拿非属主旁支去覆盖属主页 → 摄入时当场拒（review §2 安全性不减）。"""
+    _seed_owned_summary(kb)
+
+    def boom(root: Path):  # agent 不应被调用
+        raise AssertionError("非属主撞页应在跑 agent 前被拒")
+
+    rc = run_ingest("raw/2025/summary.md", root=kb, runner=make_runner(boom))
+    assert rc == EXIT_USAGE
+    assert "summary" in capsys.readouterr().err
 
 
 def test_ingest_not_a_kb_usage(tmp_path: Path):


### PR DESCRIPTION
## 背景

承 #29 的 ingest 撞名守卫 `_reject_source_slug_collision`，处理 xhigh code-review 剩余两项（#1 已在 #29 修）。

## #2（correctness）合法重摄所有权豁免

**问题**：#29 的守卫「同 slug 旁支存在即拒」太宽——`raw/2024/summary.md` 已摄入并长期维护其 `wiki/sources/summary.md`，用户后放一篇未摄草稿 `raw/2025/summary.md`，重摄 `raw/2024/summary.md` 会被误挡（EXIT_USAGE）。

**改法**：新增 `_target_page_owned_by`（复用 `provenance.parse_digest_value` 归口）——目标页已存在且其 `raw_digest` 确证归属**本文件**时**放行**。

| 场景 | 行为 |
|---|---|
| 属主重摄（页在、digest 指向本文件）+ 同 slug 旁支存在 | ✅ 放行 |
| 非属主旁支覆盖属主页 | ⛔ 摄入该旁支时当场拒（真撞，安全性不减） |
| fresh 撞名（无页、两同 slug raw `.md`） | ⛔ eager 拒（不变） |
| 所有权未确证（页缺 / 无或坏 `raw_digest` / 指纹指向别文件） | ⛔ 保守拒（不放任覆盖） |

残留（docstring 记）：`find_source_page` 的 `.`→`-` 回退（`1.报告`↔`1-报告`）键不同、不在此拦；页存在但 stamp 曾失败（无 digest）的重摄会保守拒——窄边角。

## #3（perf）已接受代价

每次 ingest 全量 `rglob` 一遍 `raw/`——与 `run_guarded_write` 里 `gate.snapshot_raw` 的既有 `raw/` 遍历同阶、更轻（后者还带哈希），故**不另优化**，在 `_reject_source_slug_collision` docstring 写明。

## 测试

- `tests/test_ingest.py` +2：`…owner_not_blocked_by_sibling`（属主重摄放行）、`…non_owner_into_owned_slug_rejected`（非属主覆盖拒绝）。
- 全量 `uv run pytest` → **1118 passed, 1 skipped**。
- 真 CLI E2E：非属主拒 / 属主放行 双向确认。

## 文档

CHANGELOG 未发布段扩成三轮收敛（basename→slug、所有权豁免、已接受 rglob 代价）+ 回填 v0.6 反向评审note 进展。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
