### PR TITLE
fix: wiki/.trash 确定性写走原子覆盖，消除半写坏页（openkb 反向评审 §2）

### DIFF
--- a/docs/backlog/notes/openkb-2026-07-反向评审.md
+++ b/docs/backlog/notes/openkb-2026-07-反向评审.md
@@ -1,0 +1,60 @@
+# OpenKB 2026-07 pull 反向评审（backlog）
+
+> 状态：**反向评审结论，非排期项**。键定 **2026-07-12 pull**（fast-forward `6194c5e→bd9fe39`，**11 个 commit**，2026-06-30→07-10）。**不改变现状，只借形状、不借实现。**
+>
+> 项目：`VectifyAI/OpenKB`（Python，PageIndex vectorless 检索 + Claude Code 插件；同 Karpathy LLM-wiki 家族，走"重 LLM 编译 + 生成器层"路线的对照实现）。本篇是 **增量 pull 键定**，只研判本次 11 commit 的净增量——逐条款主线见 [`openkb-反向评审结论.md`](openkb-反向评审结论.md)（2026-06 首审，§8 三条已落 P3.7/P3.8/P3.9，Skill Factory→P6），不回溯。
+>
+> 关联：[`openkb-反向评审结论.md`](openkb-反向评审结论.md)（逐条款主线）、[`swarmvault-反向评审.md`](swarmvault-反向评审.md) / [`gbrain-v0.42.58-反向评审.md`](gbrain-v0.42.58-反向评审.md) / [`llm_wiki-反向评审-v0.6.md`](llm_wiki-反向评审-v0.6.md)（同类同期先例，共享"委托防火墙"裁决）、[`../../P2.1-摄入写入纪律.md`](../../P2.1-摄入写入纪律.md)（gate `_check_source_regression`）、[`../../P5.2.1-图片落盘.md`](../../P5.2.1-图片落盘.md)（imageio 命名）。
+
+## 0. 一句话
+
+11 个 commit 里**穿透到观澜**的只有一项：**#142 的「wiki 写走原子」最小形状**——观澜 `wiki/` + `.trash/` 的零 LLM 写有四处裸 `write_text`（含一处**非派生内容页**、一处**撤回恢复配方**），对应 **§2 一个立即动作**，且**只借"避免半写文件"，不借 journal / crash-recovery**。其余技术大头——**#161 截断防护本体 / #154 cache_control 剥离 / #174 并发旋钮 / #175 parallel_tool_calls(Bedrock) / #163·#165 converter 图片保全**——**全落在 OpenKB 自持的 LLM / converter 层**，被观澜「LLM 全权委托 agentao、convert 委托 pdf-to-markdown skill」的委托防火墙挡下（承 swarmvault §4 `maxOutputTokens`、gbrain §4 base-url 的同款裁决）。**#159 agent-first 脚手架**（AGENTS map / golden-principles / file-size lint）与观澜既有 DESIGN/CLAUDE/P\* 重叠、**不借**（§4）；#160 图片撞名观澜已按设计规避。
+
+## 1. 新增缺口（真实的，1 个）
+
+**wiki/ 的确定性写是非原子的 —— 对照 #142「wiki 写走原子」的最小形状（只借"避免半写文件"，不借 crash-recovery）。**
+
+- **OpenKB 形状**：本次 `#142` 把 wiki 写全收进 `locks.py`（`atomic_write_text` = 同目录 tmp + `os.replace` + portalocker）与 `mutation.py`（journal + rollback + `recover_pending_journals` 崩溃恢复）。观澜只取其**最小面**——为何不借 journal/portalocker 见 §4。
+- **观澜现状（半覆盖）**：**原语已在仓内**——[`guanlan/rawio.py`](../../../guanlan/rawio.py) `atomic_write_raw`（同目录 `mkstemp` + `os.replace`）已用于 `raw/` + `convert` 图片落盘（决策P5.2.1-9）。**但 `wiki/` + `.trash/` 的确定性写没走它**，四处裸 `write_text`：
+  - **[`guanlan/remove.py`](../../../guanlan/remove.py)`:184`** `_drop_slug_from_page` —— 重写**真实 wiki 内容页**（从摘要/实体页 frontmatter 摘掉一个 source 引用后整页回写）。中断卡在写一半 → **一页非派生内容被截成半截**。这是**最尖的一处**：内容页不是能重建的派生物，损坏即真数据丢失。
+  - **[`guanlan/remove.py`](../../../guanlan/remove.py)`:242`** manifest —— 写 `.trash/<slug>/manifest.json`（撤回审计 + 人工恢复配方 + 二期 `restore` 输入，故意**先于**摘 slug/删 index/移源落盘）。半写 → **恢复配方损坏、二期 restore 无法解析 JSON**。注：它写的是**新建 `trash_dir` 下的新文件**（无旧版本可护），但原子替换仍保证读者（restore）**永不见半写配方**。
+  - **[`guanlan/remove.py`](../../../guanlan/remove.py)`:195`** `_prune_index_line` —— 重写 `index.md`。
+  - **[`guanlan/reindex.py`](../../../guanlan/reindex.py)`:252`** —— 重写 `index.md`。
+  - （**严重度序**：内容页(184) > 恢复配方(242，源仍在 `.trash/`、损的是便捷 restore 路径) > `index.md`(195/252，**可 `reindex` 幂等重建**、损坏可自愈)。）
+- **边界（明确收窄）**：同目录 tmp + `os.replace` 保证**读者永不见半写文件**，且临时文件写失败时**旧文件原封不动**。但**无文件/目录 `fsync` → 不承诺断电后的持久性**；它解决的是「**避免部分写入**」，**不是**完整 crash recovery——**不提供事务、回滚、断电持久性保证**。为何仍值得改：进程中断 / 写入失败（异常、磁盘满）时，`os.replace` 严格优于裸 `write_text`（原子换入 + 无部分写），且原语现成（rawio），零新依赖。
+
+## 2. 最小动作（立即做，1 项）
+
+> **进展更新（实现后回填，实现 2026-07-11 · xhigh 评审+扩展 2026-07-12）**：本节唯一动作**已实现并扩展** ✅。
+>
+> - **原语**：`rawio` 抽两支公共原子写——`atomic_write_bytes(target, data)` 逐字节底座 + `atomic_write_text(target, content)` UTF-8 文本外壳；`atomic_write_raw` 重构为复用文本壳（行为字节级不变，raw/ 侧 convert/web/imageio 既有测试全绿）。**覆盖既有文件保留原权限位**（xhigh code-review 发现①：`mkstemp` 的 0600 会把既有 0644 页无声窄化——覆盖前 `chmod` 回目标现权限修正）。
+> - **改用点（7 处）**：初始四处 `remove.py:184/195/243`、`reindex.py:253`（走文本壳）；**经 xhigh 评审扩展**又收编三处同类确定性 wiki 页写——`fmrepair.repair_page_frontmatter`（发现②，走字节底座保 CRLF 逐字）、`gate` 门禁回滚原字节（发现②，字节底座）、`provenance.stamp_raw_digest` stamp+回滚（发现⑤，文本壳）。**跳过**：`graph.json/html`（发现⑥，纯派生物、自愈，低优先）；CRLF-on-Windows / 符号链接换名（发现③④，新行为与既有 `atomic_write_raw` 一致，POSIX 零差异，不改）。
+> - **元数据保留**：覆盖既有文件时经 `_preserve_metadata` 保留原**权限位 + 属主 uid/gid**（best-effort）——Codex 评审两轮先后指出 `os.replace` 换新 inode 会窄化 0644→0600（已修）、并在写进程 uid≠属主时（root 服务改用户 KB）改掉属主（已修，`os.chown` best-effort + Windows 跳过）。
+> - **测试/验证**：`tests/test_atomic_write.py` 14 例（三类 × 文本+字节两路 + CRLF 逐字 + 权限/属主保留 + 新建跳过 + 经 `_drop_slug_from_page`/`fmrepair`/`provenance` 三处集成证明：写崩页不半写）。**全量 1132 passed / 1 skipped、ruff clean**，`reindex`/`remove` 端到端 CLI 冒烟通过。
+> - **有意保留的固有取舍**（Codex 第二轮两条 P2，判 WONTFIX、已在原语 docstring 记明）：① 符号链接**不写穿**（`os.replace` 换链接本身）——对本模块更安全：`fmrepair`/`provenance` 本就先拒链接，`remove`/`reindex` 不跟随即杜绝写逃逸出 KB（旧就地 `write_text` 反而会写穿）；② **不保 ACL/xattr**——`os.*xattr` 在 macOS 不可用、POSIX ACL 无标准库，对纯 markdown 无实义。二者均是 atomic-rename「新 inode」的固有面，且**既有 `atomic_write_raw` 一直如此**，非本次引入。
+>
+> 属**零 LLM 确定性写硬化**（非 P-阶段、无版本号）；余 §3 观察项、§4 不借判断不变。
+
+1. **wiki 写走原子覆盖**。加一个**无锁、无 journal 的 UTF-8 原子覆盖原语**（同目录 `mkstemp` + `os.replace`；或复用 [`rawio.py`](../../../guanlan/rawio.py) 的 tmp+replace 骨架，**去掉 raw/ 那套不覆盖门禁**——wiki 写允许覆盖，语义不同），替换 §1 四处裸 `write_text`（remove.py:184/195/242、reindex.py:252）。
+   - **硬约束**：只换**落盘方式**，**绝不动**行为 / 幂等 / 退出码 / 异常语义——`remove`/`reindex` 现有的「已删/已同步 → 不写」短路（remove.py:181 的 `slug not in sources → no-op`、reindex 的 `new_text is None → 不写`）原样保留；manifest 写在**新建 `trash_dir`** 内（同目录 tmp 落在该 trash_dir 下、`os.replace` 换入，语义不变）；**不引 portalocker、不做事务恢复、不加断电持久性承诺**。
+   - **测试三类**：① 成功覆盖（内容如期替换）；② 写临时文件失败时**旧文件不变**（覆盖写的 184/195/252 三处；manifest 242 为新建文件，此项退化为"失败则该文件不存在、不留半截"）；③ 临时文件清理（失败路径不残留 `.tmp`）。
+
+## 3. 仅观察（不排期，1 个）
+
+- **截断/畸形 LLM 输出的静默丢数据（`#161`）—— gate 已覆盖一半，残余面待实证**。OpenKB 两坑：① 响应是 JSON 数组而非对象 → 崩在 `.get()` → 页被丢弃，且**因索引已记为已写 → 永不重试**；② `finish_reason=length` 被 `json_repair` 救回后**照写** → 用截断内容**覆盖好页**却仍报 `[OK]`。
+  - 观澜 gate 的 `_check_source_regression`（P2.1 dropped/shrank 检测）**已覆盖 ②**：既有页被写小 → `EXIT_*` 拦死，好页保住。
+  - **残余（两点，均先观察）**：(a) *新建*页被截断时**无写前版本可比 shrink**，gate 不一定拦——但 `check` 的 frontmatter/断链校验可能兜住畸形页；(b) 更值得对照的是 ① 那个「**已记入 index/log → 永不补写**」陷阱：建议对照审一遍 `log.md`/ingest 幂等——一次 ingest 里某页写残，下次会不会因已登记而**不再补写**。
+  - **为何不排期**：修复本体在 skill/agentao 手里（观澜 wrapper **无 per-page JSON 解析、无 `raise_on_truncation` 可加**——那是不变量：脚本零 LLM）。gate 是观澜唯一防线，现有覆盖已挡住最常见的"覆盖变短"。**先观察，出真实「写残页不自愈」报障再动。**
+
+## 4. 不借 / N/A（附理由）
+
+- **`#159` agent-first 脚手架（AGENTS map / golden-principles / file-size lint / mypy gate）—— 不借，避免重复真相源**。OpenKB 走 agent-first，把"文件 < 800 行"等机械规则 promote 成 lint、用 `AGENTS.md` 当 Codex/Claude 共读地图、`docs/golden-principles.md` 集中约定。观澜**已有** `DESIGN.md`（权威 spec）+ `CLAUDE.md`（红线/命令）+ 每阶段 `P*.md`；再叠一套 golden-principles / AGENTS map 是**重复真相源**，维护成本 > 收益。**文件过大继续由 code review 判断**——800 行是任意阈值，不衡量职责是否混杂，反诱导机械拆文件 / 把代码压到 799 行；等真实维护痛点出现，再针对**具体模块**拆分，不先造通用门禁。mypy 进 CI 同理：起步要一大片 `disable_error_code`（OpenKB 自己就是），收益待实证，**非本批动作**。
+- **`#161` 截断防护本体 / `#154` cache_control 剥离 / `#174` index·compile 并发旋钮 / `#175` parallel_tool_calls(Bedrock)** —— **全在 LLM client 层，N/A**。观澜 LLM 全权委托 agentao 子进程（不变量：脚本零 LLM、无 API key、不自截 output token、不自持 provider 路由）。这些**具体故障链在观澜 wrapper 根本不存在**；若 agentao 未来多-provider 化，是**那边**该抄的清单（同 swarmvault §4 `maxOutputTokens`、gbrain §4 base-url 的裁决——同期几篇同形：**技术大头被委托防火墙挡下**）。
+- **`#163` preserve docx embedded images / `#165` keep_data_uris（converter/markitdown）—— N/A，委托 skill**。观澜 `convert` 只做零 LLM 宿主写，实际转换 shell 给 `pdf-to-markdown` skill 的外部后端（MinerU/marker/pypdf，见 CLAUDE.md）。docx 内嵌图保全是**那个 skill/后端**的职责，不是观澜 wrapper 的活。
+- **`#160` 图片同 basename 撞名 —— 已按设计规避，别借**。OpenKB 坑：`a/logo.png` 与 `b/logo.png` 落到同一 `sources/images/<doc>/logo.png` 互相覆盖，需 suffix `logo_1.png`。观澜 [`imageio.py`](../../../guanlan/imageio.py) 把**所有**图重命名成 `images/<stem>/<stem>-<n>.ext`（**按计数器、per-doc 命名空间、不保留原 basename**，imageio.py:164）——跨-basename 撞名**结构上不可能发生**。观澜的对偶风险"同一图被引两次落两份"，已由 `collected[key]`/`order` 去重（imageio.py:165）解掉。
+- **`#155` 别对全量 blob store 每次 add 快照 —— 观澜已在更好位置**。OpenKB 坑：每次 add `hardlink` 整个 blob store（无硬链文件系统时退化成整树字节拷贝），成本随 **KB 总量**涨而非随本次文档。观澜 `snapshot_raw`（[`gate.py`](../../../guanlan/gate.py)）也扫全量 `raw/` 树，但取的是 **stat 指纹（filename+size+mtime，必要时 SHA256）非 hardlink/copy**——已比 OpenKB 便宜一个量级。残余仅"意识"：raw/ 极大时 ingest 前后双扫仍 O(总文件数)；stat 廉价，**先不优化**。
+- **`#156` serial add 走 coordinator / `#142` 的 journal + crash-recovery 本体 —— 形状借（→§2），重机械不借**。OpenKB 要 coordinator + journal + `recover_pending_journals`，是因它支持**并发多 add**、且 blob store + `pageindex.db` 多物需事务性回滚。观澜 ingest 是**单个 Agentao 子进程 + 前后 `raw/` 快照门禁**——**无并发写者、无多物事务**；wiki 写崩溃的兜底是「markdown 唯一真相 + 派生物可幂等重建 + git 可回滚」。故只借 #142 的**「wiki 写要原子」最小形状**（§2），**不借** journal/coordinator/portalocker（对观澜 over-engineered）。
+
+---
+
+**收口**：本次 pull 对观澜的净增量 = **§2 一项**（wiki 确定性写走**原子覆盖**，避免半写文件——**不假装做 crash recovery**）。OpenKB 这批的技术大头全被「委托 agentao / 委托 skill」的防火墙挡下，#159 元流程与观澜既有 DESIGN/CLAUDE/P\* 重叠故不借——与 swarmvault、gbrain、llm_wiki 同期几篇的裁决**同形**：观澜薄壳边界越清晰，能穿透的越少；而穿透进来的（wiki 写非原子）**就越该修，且要修得最小**——只避免半写，不引锁、不做事务、不建新的元文档体系。

--- a/guanlan/fmrepair.py
+++ b/guanlan/fmrepair.py
@@ -28,6 +28,7 @@ import yaml
 
 from .check import Violation
 from .pages import parse_frontmatter, split_frontmatter
+from .rawio import atomic_write_bytes  # 字节级原子覆盖写：保 CRLF 保真 + 避免半写坏页
 
 __all__ = ["repair_page_frontmatter", "repair_unparsable_pages"]
 
@@ -95,8 +96,10 @@ def repair_page_frontmatter(path: Path, wiki: Path) -> bytes | None:
     - **拒符号链接 / 越界路径**：`write_bytes` 跟随符号链接，而 `iter_pages` 经 `is_file()` 会把指向库外的
       `wiki/` 符号链接页纳入校验——若不挡，宿主代码会改动 KB 之外的文件。故页本身是符号链接、或解析后逃出
       `wiki/`（父目录符号链接）一律跳过、返回 None。
-    - **逐字节 I/O**：`read_bytes`/`write_bytes` 避开 `read_text` 换行翻译（否则 CRLF 被静默改成 LF、连带
-      改动正文与 `---` 分隔行）；只替换 frontmatter 块段，原 `---` 行与 body 逐字节不变。
+    - **逐字节 I/O**：`read_bytes` + `atomic_write_bytes` 避开 `read_text` 换行翻译（否则 CRLF 被静默改成
+      LF、连带改动正文与 `---` 分隔行）；只替换 frontmatter 块段，原 `---` 行与 body 逐字节不变。写经
+      `atomic_write_bytes`（同目录 tmp + `os.replace`）：崩在写一半也不留半写坏页（页已过符号链接闸，
+      故 rename 换名与旧 `write_bytes` 落点一致）。
     """
     # 安全闸：符号链接页 / 解析后逃出 wiki/ 的路径不修（修复是可选优化，越界即跳过、最差=现状）。
     if path.is_symlink():
@@ -124,7 +127,7 @@ def repair_page_frontmatter(path: Path, wiki: Path) -> bytes | None:
     lines = text.splitlines(keepends=True)
     close = next(i for i in range(1, len(lines)) if lines[i].strip() == "---")
     new_text = lines[0] + new_block + lines[close] + "".join(lines[close + 1:])
-    path.write_bytes(new_text.encode("utf-8"))
+    atomic_write_bytes(path, new_text.encode("utf-8"))  # 字节保真 + 原子换名，不留半写坏页
     return original
 
 

--- a/guanlan/gate.py
+++ b/guanlan/gate.py
@@ -29,6 +29,7 @@ from .errors import (
 )
 from .fmrepair import repair_unparsable_pages
 from .pages import iter_pages, load_page
+from .rawio import atomic_write_bytes  # 门禁回滚原字节：原子换名，回滚本身也不留半写
 from .runtime import AgentRunner, AgentRunResult, run_agent_task
 
 # 写入口门禁失败后的有界自愈轮数（决策7，见 docs/P2-最小闭环.md §10）。
@@ -475,7 +476,7 @@ def run_guarded_write_result(
             )
             stuck = {rel for rel in written if any(v.page == rel for v in probe.violations)}
             for rel in stuck:
-                (Path(root) / rel).write_bytes(written[rel])  # 仍阻断 → 回滚到原字节，最差=现状
+                atomic_write_bytes(Path(root) / rel, written[rel])  # 仍阻断 → 原子回滚到原字节，最差=现状
             kept = [rel for rel in sorted(written) if rel not in stuck]
             if kept:
                 print(

--- a/guanlan/provenance.py
+++ b/guanlan/provenance.py
@@ -25,6 +25,7 @@ from pathlib import Path
 import yaml
 
 from .pages import split_frontmatter
+from .rawio import atomic_write_text  # 原子覆盖写 source 页 frontmatter：stamp / 回滚均不留半写
 
 __all__ = [
     "RAW_DIGEST_KEY",
@@ -128,14 +129,14 @@ def stamp_raw_digest(source_page: Path, digest_value: str) -> bool:
     dumped = yaml.safe_dump(meta, allow_unicode=True, sort_keys=False)
     new_text = f"---\n{dumped}---\n{body}"
     try:
-        source_page.write_text(new_text, encoding="utf-8")
+        atomic_write_text(source_page, new_text)  # 原子覆盖：崩在写一半不留坏页
     except OSError:
         return False
     if _verify_stamp(source_page, digest_value):
         return True
     # 写后 check 不过 → 回滚到写前字节（宁可不 stamp 也绝不留坏页）。
     try:
-        source_page.write_text(original, encoding="utf-8")
+        atomic_write_text(source_page, original)  # 回滚同样原子，不留半写
     except OSError:
         pass
     return False

--- a/guanlan/rawio.py
+++ b/guanlan/rawio.py
@@ -16,6 +16,12 @@
   （`EXIT_USAGE`→409「已存在」、`EXIT_AGENT_ERROR`→500「写盘失败」）；若也改成 raise，
   worker 会把异常归一成 agent error，409 退化成 500，破 P4.6「零行为变更」硬门。
 
+`atomic_write_raw` 的 tmp+`os.replace` 落盘骨架抽成两支公共原语（无门禁、允许覆盖、覆盖保留原权限位、
+只避免半写、不 raise `ValueError`）：**`atomic_write_bytes(target, data)`** 逐字节底座、
+**`atomic_write_text(target, content)`** 是其 UTF-8 文本外壳。既是 `atomic_write_raw` 的底座，也供
+`wiki/` + `.trash/` 的确定性写复用——`remove`/`reindex`/`provenance` 走文本壳，`fmrepair`（CRLF 保真）
+与 `gate` 回滚（原字节）走字节底座——单一实现，杜绝多处落盘规则漂移。
+
 本模块不含任何路由 / 可变状态，故可独立单测、与 web 解耦；`web/rawfeed.py` 保留薄壳
 re-export 旧名（`_raw_slug` / `_normalize_basename` / …）并把校验 `ValueError` 包成
 `HTTPException(400)`，字节行为不变。
@@ -184,25 +190,88 @@ def apply_origin(text: str, origin: str) -> str:
     return f"---\n{dumped}---\n{body}"
 
 
-def atomic_write_raw(target: Path, content: str, overwrite: bool) -> int:
-    """在**串行 worker turn 内**复检覆盖语义并原子落盘（决策P4.1-2/3）。返回退出码。
+def _preserve_metadata(tmp: str, target: Path) -> None:
+    """覆盖既有文件前，把 tmp 的**权限位 + 属主（uid/gid）**对齐目标现值（best-effort，不阻断写）。
 
-    两个并发同名投喂时端点的 existence 预检可能都放过；故这里在真正串行的临界区里再查一次
-    `overwrite`，第二个返回 `EXIT_USAGE`（端点转 409）。落盘写同目录临时文件再 `os.replace`
-    换名（原子）；IO 异常（`OSError`）向上抛——web 由 worker 归一为 EXIT_AGENT_ERROR（端点转
-    500），CLI `convert` 由命令壳 `except OSError` 转 EXIT_USAGE（决策P5.2-6）。**绝不抛
-    `ValueError`**：否则 worker 把同名冲突归一成 agent error，web 的 409 退化成 500。
+    `os.replace` 换入的是 `mkstemp` 的新 inode（`0600`、属主=写进程），会丢掉被覆盖文件原 inode 的
+    元数据，与被替换的就地 `Path.write_bytes`/`write_text`（改原 inode、保 mode+uid/gid）不符：
+    - **权限位**：不回填则既有 `0644` 页无声窄化到 owner-only。
+    - **属主**：写进程 uid ≠ 目标属主时（如 root 服务更新用户 KB），文件被改成写进程所有，用户反而失去
+      编辑权。故覆盖前 `chown` 回目标 uid/gid。
+
+    目标不存在（新建，如 `.trash/manifest.json`）→ `stat` 抛 → 直接返回、保持 `mkstemp` 默认。`chmod`/
+    `chown` 各自 `suppress(OSError)`：非 root 无权把 tmp `chown` 成他人属主时静默跳过（此时旧的就地写也
+    无法保留他人属主，行为相当）；Windows 无 `os.chown` → 跳过该步。
     """
-    if target.exists() and not overwrite:
-        print(f"raw/{target.name} 已存在。")  # 经 worker redirect_stdout → job.output（409 detail）
-        return EXIT_USAGE
+    try:
+        st = os.stat(target)
+    except OSError:
+        return  # 目标不存在 → 新建，保持 mkstemp 的 0600 + 写进程属主
+    with contextlib.suppress(OSError):
+        os.chmod(tmp, st.st_mode & 0o777)
+    if hasattr(os, "chown"):  # Windows 无 chown
+        with contextlib.suppress(OSError):
+            os.chown(tmp, st.st_uid, st.st_gid)
+
+
+def atomic_write_bytes(target: Path, data: bytes) -> None:
+    """字节级原子覆盖写 `target`：同目录临时文件 + `os.replace` 换名。**是本模块所有原子写的字节底座。**
+
+    **只保证「读者永不见半写文件」「写临时文件失败时旧文件原封不动」**——同目录 tmp 落盘、成功后
+    `os.replace` 单次换入（同文件系统内原子 rename）；写 tmp 中途 `OSError`（异常 / 磁盘满）→ 清理
+    tmp 后**继续上抛**，`target` 原文未触。
+
+    **明确不做**：不 `fsync`（故**不承诺断电后的持久性**）、不加锁、不做 journal / 事务 / 回滚。它
+    解决的是「避免部分写入」，**不是**完整 crash recovery（决策见 `docs/backlog/notes/openkb-2026-07-反向评审.md` §1/§2）。
+
+    **atomic-rename 的固有取舍（有意保留，同既有 `atomic_write_raw`）**：`os.replace` 换入的是新 inode，
+    故（a）**目标是符号链接时替换的是链接本身、不写穿到 referent**——对本模块所有调用方这更安全：
+    `fmrepair`/`provenance` 本就先 `is_symlink()` 拒链接（防写出 KB 外），`remove`/`reindex` 的页/index 若
+    为链接，不跟随即杜绝写逃逸（旧的就地 `write_text` 会写穿到 KB 外）；（b）**不保留 ACL / 扩展属性**
+    （POSIX ACL 无标准库、`os.*xattr` 在 macOS 本就不可用）——对纯 markdown 页无实义，且原子写通用如此。
+    需要写穿链接或保 ACL/xattr 的场景不在本原语职责内。
+
+    **逐字节写入**（`wb`，不做任何编码 / 行尾翻译）：供已自管编码/换行、需字节保真的调用方——
+    `fmrepair` 的 CRLF 保真页修复、`gate` 的原字节回滚；`atomic_write_text` 是它按 UTF-8 编码的文本外壳。
+    允许覆盖（与 `atomic_write_raw` 的不覆盖门禁语义不同）；`target.parent` 须已存在（`mkstemp` 前置，同
+    `Path.write_bytes`）。**覆盖既有文件时保留原权限位 + 属主**（`_preserve_metadata`，best-effort）：否则
+    `os.replace` 会把页无声窄化到 `0600` 并改掉 uid/gid；新建文件保持 `mkstemp` 的 `0600` + 写进程属主。
+    """
     fd, tmp = tempfile.mkstemp(dir=str(target.parent), suffix=".tmp")
     try:
-        with os.fdopen(fd, "w", encoding="utf-8", newline="") as f:
-            f.write(content)  # UTF-8 原样：不渲染、不重写 [[wikilink]]（raw/ 是未加工源）。
+        with os.fdopen(fd, "wb") as f:
+            f.write(data)
+        _preserve_metadata(tmp, target)  # 覆盖时保留原权限位 + 属主（best-effort）
         os.replace(tmp, target)
     except OSError:
         with contextlib.suppress(OSError):
             os.unlink(tmp)
         raise
+
+
+def atomic_write_text(target: Path, content: str) -> None:
+    """UTF-8 原子覆盖写 `target`（`atomic_write_bytes` 的文本外壳，语义/保证与之相同）。
+
+    `content` 按 UTF-8、**逐字写盘**（不做行尾翻译，等价旧 `newline=""`）：自管 EOL 的调用方（如
+    `reindex._join_lines` 按探测 EOL 重组）原样保真，硬编码 `\\n` 的调用方在 POSIX 上字节等同。覆盖保留
+    原权限位、写失败旧文件不动、不 fsync/锁/journal——细节见 `atomic_write_bytes`。供 `wiki/` + `.trash/`
+    的确定性写（`remove` / `reindex` / `provenance`）替代裸 `Path.write_text`。
+    """
+    atomic_write_bytes(target, content.encode("utf-8"))
+
+
+def atomic_write_raw(target: Path, content: str, overwrite: bool) -> int:
+    """在**串行 worker turn 内**复检覆盖语义并原子落盘（决策P4.1-2/3）。返回退出码。
+
+    两个并发同名投喂时端点的 existence 预检可能都放过；故这里在真正串行的临界区里再查一次
+    `overwrite`，第二个返回 `EXIT_USAGE`（端点转 409）。通过后走 `atomic_write_text` 原子落盘
+    （同目录 tmp + `os.replace`，UTF-8 原样：不渲染、不重写 `[[wikilink]]`——raw/ 是未加工源）；IO
+    异常（`OSError`）向上抛——web 由 worker 归一为 EXIT_AGENT_ERROR（端点转 500），CLI `convert`
+    由命令壳 `except OSError` 转 EXIT_USAGE（决策P5.2-6）。**绝不抛 `ValueError`**：否则 worker 把
+    同名冲突归一成 agent error，web 的 409 退化成 500。
+    """
+    if target.exists() and not overwrite:
+        print(f"raw/{target.name} 已存在。")  # 经 worker redirect_stdout → job.output（409 detail）
+        return EXIT_USAGE
+    atomic_write_text(target, content)
     return EXIT_OK

--- a/guanlan/reindex.py
+++ b/guanlan/reindex.py
@@ -21,6 +21,7 @@ from pathlib import Path
 from .errors import EXIT_OK, GuanlanError
 from .pages import index_md_links, index_sync_state, iter_pages, load_page, page_title
 from .paths import require_kb_root
+from .rawio import atomic_write_text  # 原子覆盖写 index.md（避免半写），与 raw/ 写共用骨架
 
 __all__ = [
     "ReindexEntry",
@@ -249,7 +250,7 @@ def reindex_entrypoint(
     wiki = root / "wiki"
     result, new_text = run_reindex(wiki, prune=prune)
     if not dry_run and new_text is not None:
-        (wiki / "index.md").write_text(new_text, encoding="utf-8")
+        atomic_write_text(wiki / "index.md", new_text)
     print(format_result(result, dry_run=dry_run, json_output=json_output))
     return EXIT_OK
 

--- a/guanlan/remove.py
+++ b/guanlan/remove.py
@@ -33,7 +33,7 @@ from .errors import EXIT_OK, EXIT_USAGE, GuanlanError
 from .gate import _trusted_sources  # 读衍生页可信 sources 的单一归口（坏/缺 → None）
 from .pages import iter_pages, load_page, split_frontmatter
 from .paths import require_kb_root
-from .rawio import normalize_basename, raw_slug  # slug 归一：与投喂 / convert 建源同口径
+from .rawio import atomic_write_text, normalize_basename, raw_slug  # slug 归一 + 原子写（避免半写）同口径
 from .reindex import _join_lines, _prune_dangling, _split_lines  # index 行删除的单一归口
 
 __all__ = [
@@ -181,7 +181,7 @@ def _drop_slug_from_page(path: Path, slug: str) -> bool:
         return False  # 幂等：重跑时 slug 已不在 → no-op
     meta["sources"] = [s for s in sources if s != slug]
     dumped = yaml.safe_dump(meta, allow_unicode=True, sort_keys=False)
-    path.write_text(f"---\n{dumped}---\n{body}", encoding="utf-8")
+    atomic_write_text(path, f"---\n{dumped}---\n{body}")  # 原子覆盖：崩溃不把内容页写成半截
     return True
 
 
@@ -192,7 +192,7 @@ def _prune_index_line(index_path: Path, slug: str) -> list[str]:
     lines, eol, trailing = _split_lines(index_path.read_text(encoding="utf-8"))
     kept, removed = _prune_dangling(lines, _index_target(slug))
     if removed:
-        index_path.write_text(_join_lines(kept, eol, trailing), encoding="utf-8")
+        atomic_write_text(index_path, _join_lines(kept, eol, trailing))  # 自管 EOL、逐字原子写
     return removed
 
 
@@ -239,8 +239,9 @@ def _execute(root: Path, plan: RemovePlan) -> Path:
         "orphaned": list(plan.orphans),  # 独源孤儿（未改动）——记入审计/blast-radius，非恢复所需
         "index_lines_removed": list(plan.index_lines),
     }
-    (trash_dir / "manifest.json").write_text(
-        json.dumps(manifest, ensure_ascii=False, indent=2) + "\n", encoding="utf-8"
+    # 原子写：半写的恢复配方会让二期 restore 无法解析 JSON；新建文件下失败则不残留半截。
+    atomic_write_text(
+        trash_dir / "manifest.json", json.dumps(manifest, ensure_ascii=False, indent=2) + "\n"
     )
 
     # ② 摘多源页 slug（幂等）→ ③ 删 index 行（从当前文件重算，幂等）→ ④ 最后移源

--- a/tests/test_atomic_write.py
+++ b/tests/test_atomic_write.py
@@ -1,0 +1,194 @@
+"""`atomic_write_text` 原子覆盖写测试（wiki/ + .trash/ 确定性写去半写）。
+
+见 `docs/backlog/notes/openkb-2026-07-反向评审.md` §2：三类——① 成功覆盖、② 写失败时旧文件
+不变、③ 失败路径不残留 `.tmp`；外加 `newline=""` 逐字保真，以及经 `remove._drop_slug_from_page`
+的集成证明（写崩不把内容页截成半截）。**只避免半写，不做 crash recovery**。
+"""
+
+import os
+from pathlib import Path
+
+import pytest
+
+from guanlan.rawio import atomic_write_bytes, atomic_write_text
+
+
+def _boom(*_args, **_kwargs):
+    raise OSError("replace failed")
+
+
+def test_creates_new_file(tmp_path: Path) -> None:
+    """① 新建：内容如期落盘。"""
+    target = tmp_path / "new.md"
+    atomic_write_text(target, "内容\n")
+    assert target.read_text(encoding="utf-8") == "内容\n"
+
+
+def test_overwrites_existing(tmp_path: Path) -> None:
+    """① 覆盖：旧内容被新内容原子替换。"""
+    target = tmp_path / "p.md"
+    target.write_text("旧内容", encoding="utf-8")
+    atomic_write_text(target, "新内容")
+    assert target.read_text(encoding="utf-8") == "新内容"
+
+
+def test_verbatim_no_eol_translation(tmp_path: Path) -> None:
+    """`newline=""` 逐字写：自管 EOL 的调用方（reindex._join_lines）CRLF 不被翻译/双写。"""
+    target = tmp_path / "crlf.md"
+    atomic_write_text(target, "a\r\nb\r\n")
+    assert target.read_bytes() == b"a\r\nb\r\n"
+
+
+def test_overwrite_preserves_existing_mode(tmp_path: Path) -> None:
+    """覆盖既有文件保留原权限位：不把 0644 页无声窄化到 mkstemp 的 0600（code-review 发现①）。"""
+    target = tmp_path / "p.md"
+    target.write_text("旧", encoding="utf-8")
+    os.chmod(target, 0o644)
+    atomic_write_text(target, "新")
+    assert oct(target.stat().st_mode & 0o777) == oct(0o644)
+
+
+def test_overwrite_preserves_ownership_best_effort(tmp_path: Path, monkeypatch) -> None:
+    """覆盖既有文件时 `chown(tmp, 目标 uid/gid)`——root 改用户 KB 场景不把页改成写进程所有（Codex P2）。
+
+    非 root 无法真把 tmp chown 成他人属主，故只断言"用目标现属主发起了 chown"（保留路径已执行）。"""
+    if not hasattr(os, "chown"):
+        pytest.skip("平台无 os.chown")
+    target = tmp_path / "p.md"
+    target.write_text("旧", encoding="utf-8")
+    st = target.stat()
+    calls: list[tuple[int, int]] = []
+    real_chown = os.chown
+
+    def spy_chown(path, uid, gid):
+        calls.append((uid, gid))
+        return real_chown(path, uid, gid)
+
+    monkeypatch.setattr("guanlan.rawio.os.chown", spy_chown)
+    atomic_write_text(target, "新")
+    assert calls and calls[-1] == (st.st_uid, st.st_gid)  # 以目标现 uid/gid chown tmp
+    assert target.read_text(encoding="utf-8") == "新"
+
+
+def test_new_file_skips_metadata_preserve(tmp_path: Path, monkeypatch) -> None:
+    """新建文件（目标不存在）不尝试 chmod/chown：保持 mkstemp 默认 + 写进程属主。"""
+    called = {"chmod": False, "chown": False}
+    monkeypatch.setattr("guanlan.rawio.os.chmod", lambda *a, **k: called.__setitem__("chmod", True))
+    if hasattr(os, "chown"):
+        monkeypatch.setattr("guanlan.rawio.os.chown", lambda *a, **k: called.__setitem__("chown", True))
+    atomic_write_text(tmp_path / "new.md", "内容")
+    assert called == {"chmod": False, "chown": False}
+
+
+def test_replace_failure_leaves_old_file_and_no_tmp(tmp_path: Path, monkeypatch) -> None:
+    """② + ③：`os.replace` 崩 → 旧文件原封不动、目录不残留 `.tmp`。"""
+    target = tmp_path / "p.md"
+    target.write_text("旧内容", encoding="utf-8")
+    monkeypatch.setattr("guanlan.rawio.os.replace", _boom)
+    with pytest.raises(OSError):
+        atomic_write_text(target, "新内容")
+    assert target.read_text(encoding="utf-8") == "旧内容"  # ② 旧文件不变
+    assert list(tmp_path.glob("*.tmp")) == []  # ③ tmp 已清理
+
+
+def test_replace_failure_on_new_file_leaves_nothing(tmp_path: Path, monkeypatch) -> None:
+    """新建文件写失败（manifest 242 场景）：目标不存在、不留半截、无 `.tmp`。"""
+    target = tmp_path / "manifest.json"
+    monkeypatch.setattr("guanlan.rawio.os.replace", _boom)
+    with pytest.raises(OSError):
+        atomic_write_text(target, '{"k": "v"}\n')
+    assert not target.exists()
+    assert list(tmp_path.glob("*.tmp")) == []
+
+
+def test_drop_slug_from_page_write_is_atomic(tmp_path: Path, monkeypatch) -> None:
+    """集成证明：`remove._drop_slug_from_page` 经 `atomic_write_text`——写崩则内容页不被截断。
+
+    若该写点仍是裸 `Path.write_text`，patch `os.replace` 不会影响它、页会被改写；走原子写则
+    `os.replace` 崩使整页保持原字节。"""
+    from guanlan.remove import _drop_slug_from_page
+
+    page = tmp_path / "s.md"
+    original = "---\nsources:\n- a\n- b\n---\n正文一字不改。\n"
+    page.write_text(original, encoding="utf-8")
+    monkeypatch.setattr("guanlan.rawio.os.replace", _boom)
+    with pytest.raises(OSError):
+        _drop_slug_from_page(page, "a")
+    assert page.read_text(encoding="utf-8") == original  # 内容页未被截成半截
+
+
+# --- atomic_write_bytes：逐字节底座（fmrepair CRLF 保真 + gate 原字节回滚走它）---
+
+
+def test_bytes_writes_verbatim(tmp_path: Path) -> None:
+    """逐字节写：CRLF / NUL / 非文本字节一律原样落盘（不做编码/行尾翻译）。"""
+    target = tmp_path / "b.bin"
+    data = b"a\r\nb\x00\xf0\x9f\x98\x80\r\n"
+    atomic_write_bytes(target, data)
+    assert target.read_bytes() == data
+
+
+def test_bytes_overwrite_preserves_mode(tmp_path: Path) -> None:
+    """字节底座覆盖同样保留原权限位（fmrepair/gate 回滚不窄化页权限）。"""
+    target = tmp_path / "b.md"
+    target.write_bytes(b"old")
+    os.chmod(target, 0o644)
+    atomic_write_bytes(target, b"new")
+    assert oct(target.stat().st_mode & 0o777) == oct(0o644)
+
+
+def test_bytes_replace_failure_leaves_old_and_no_tmp(tmp_path: Path, monkeypatch) -> None:
+    """② + ③（字节路径）：`os.replace` 崩 → 旧文件不变、无残留 `.tmp`。"""
+    target = tmp_path / "b.md"
+    target.write_bytes(b"old")
+    monkeypatch.setattr("guanlan.rawio.os.replace", _boom)
+    with pytest.raises(OSError):
+        atomic_write_bytes(target, b"new")
+    assert target.read_bytes() == b"old"
+    assert list(tmp_path.glob("*.tmp")) == []
+
+
+def test_fmrepair_atomic_and_crlf_verbatim(tmp_path: Path, monkeypatch) -> None:
+    """集成证明：`fmrepair.repair_page_frontmatter` 经 `atomic_write_bytes`——修好仍 CRLF 逐字，
+    且 `os.replace` 崩则坏页保持原字节（不留半写）。"""
+    import yaml
+
+    from guanlan.fmrepair import repair_page_frontmatter
+    from guanlan.pages import split_frontmatter
+
+    concepts = tmp_path / "wiki" / "concepts"
+    concepts.mkdir(parents=True)
+    page = concepts / "Foo.md"
+    original = (
+        '---\r\ntitle: "他说"你好""\r\ntype: concept\r\ntags: []\r\n'
+        "sources: []\r\nlast_updated: 2026-06-03\r\n---\r\n正文行。\r\n"
+    ).encode("utf-8")
+
+    # ① 正常修复：返回原字节；frontmatter 现可解析为映射；CRLF 与正文逐字保留。
+    page.write_bytes(original)
+    assert repair_page_frontmatter(page, tmp_path / "wiki") == original
+    fixed = page.read_bytes()
+    assert "\r\n正文行。\r\n".encode("utf-8") in fixed  # body + CRLF 逐字未动
+    block, _body = split_frontmatter(fixed.decode("utf-8"))
+    assert isinstance(yaml.safe_load(block), dict)  # 引号已修好、块可解析
+
+    # ② os.replace 崩 → 坏页保持原字节（atomicity）。
+    page.write_bytes(original)
+    monkeypatch.setattr("guanlan.rawio.os.replace", _boom)
+    with pytest.raises(OSError):
+        repair_page_frontmatter(page, tmp_path / "wiki")
+    assert page.read_bytes() == original
+
+
+def test_provenance_stamp_is_atomic(tmp_path: Path, monkeypatch) -> None:
+    """集成证明：`provenance.stamp_raw_digest` 经 `atomic_write_text`——`os.replace` 崩 →
+    捕获 OSError 返回 False，且 source 页未被半写。"""
+    from guanlan.provenance import stamp_raw_digest
+
+    page = tmp_path / "wiki" / "sources" / "s.md"
+    page.parent.mkdir(parents=True)
+    original = "---\ntitle: 源\ntype: source\nsources: []\n---\n摘要正文够长。\n"
+    page.write_text(original, encoding="utf-8")
+    monkeypatch.setattr("guanlan.rawio.os.replace", _boom)
+    assert stamp_raw_digest(page, "sha256:deadbeef") is False  # 写崩被吞 → False
+    assert page.read_text(encoding="utf-8") == original  # 页未被半写


### PR DESCRIPTION
## 背景

`wiki/` 的零 LLM 确定性写此前用裸 `Path.write_text`/`write_bytes`：进程中断 / 磁盘满卡在写一半会把**权威 markdown**（内容页、`index.md`、`.trash` 撤回恢复配方、frontmatter 修复页）截成半截。对照 OpenKB #142 golden-principles「所有 wiki 写走原子」（[openkb-2026-07 反向评审](docs/backlog/notes/openkb-2026-07-反向评审.md) §2），而 `rawio` 早有的 `atomic_write_raw`（tmp + `os.replace`）此前只用在 `raw/`。

## 改动

- **原语**：`rawio` 抽两支公共原子写——`atomic_write_bytes(target, data)` 逐字节底座 + `atomic_write_text(target, content)` UTF-8 文本外壳；`atomic_write_raw` 重构为复用文本壳（字节级行为不变）。单一实现，杜绝多处落盘规则漂移。
- **7 处确定性 wiki/.trash 写改用原语**：

  | 站点 | 文件 | 原语 |
  |---|---|---|
  | 内容页摘 slug | `remove.py:184` | 文本壳 |
  | index 剪枝 / 回填 | `remove.py:195`, `reindex.py:253` | 文本壳 |
  | `.trash` manifest | `remove.py:243` | 文本壳 |
  | frontmatter 引号修复 | `fmrepair.py:127` | 字节底座（CRLF 保真） |
  | 门禁回滚原字节 | `gate.py:478` | 字节底座 |
  | raw_digest stamp + 回滚 | `provenance.py:131/138` | 文本壳 |

- **`_preserve_metadata`**：覆盖既有文件时保留原**权限位 + 属主 uid/gid**（best-effort）——否则 `os.replace` 换新 inode 会把 `0644` 页窄化到 `0600` 并改掉属主（Codex 评审两轮 P2，均已修）。

## 有意保留的固有取舍（atomic-rename「新 inode」，同既有 `atomic_write_raw`）

- **符号链接不写穿**：对本模块更安全——`fmrepair`/`provenance` 本就先拒链接，`remove`/`reindex` 不跟随即杜绝写逃逸出 KB（旧就地写反而会写穿）。
- **不保 ACL/xattr**：`os.*xattr` 在 macOS 不可用、POSIX ACL 无标准库，对纯 markdown 无实义。

均在原语 docstring 记明；判 WONTFIX 的完整理由见反向评审 §2 状态戳。

## 测试

`tests/test_atomic_write.py` 14 例：三类失败模式 × 文本/字节两路 + CRLF 逐字 + 权限/属主保留 + 新建跳过 + 经 `_drop_slug_from_page`/`fmrepair`/`provenance` 三处集成证明（写崩页不半写）。

- ✅ 全量 **1132 passed / 1 skipped**、`ruff` clean
- ✅ `reindex` / `remove` 端到端 CLI 冒烟通过
- ✅ raw/ 侧 `atomic_write_raw` 既有 convert/web/imageio 测试全绿（重构无回归）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
