### PR TITLE
fix: 交给 agentao 前剔除毒空 *_API_KEY，修 Claude Code 会话里「.env 有真 key 却报无 key」

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,25 @@
 
 ### 修复
 
+- **在 Claude Code 会话里跑 `guanlan` 时「`.env` 有真 key 却报无 key」（源自 gbrain v0.42.58 反向评审 §2，
+  探针 gbrain #1249，见 [`docs/backlog/notes/gbrain-v0.42.58-反向评审.md`](docs/backlog/notes/gbrain-v0.42.58-反向评审.md)）**
+  —— Claude Code 会给子进程注入 `ANTHROPIC_API_KEY=''` 以掐断子进程的 LLM 调用；而 agentao 的
+  `safe_load_dotenv` 用 `os.environ.setdefault`（no-override），**空串也算「已设置」**，于是 `.env` 里的真 key
+  永远 setdefault 不进来，`os.getenv` 恒返空串。触发面：**provider = Anthropic 且从 Claude Code 会话里跑
+  `guanlan ingest/query/web`**（OpenAI provider 不受影响——Claude Code 不注入 `OPENAI_API_KEY=''`）。
+  现在两条 LLM 路径在交给 agentao **之前**都剔除毒空值：CLI 子进程路径 `runtime._subprocess_runner` 显式传
+  `env=scrubbed_environ()`（不再裸继承父环境）；Web 进程内嵌入路径在 `chat.build_from_environment` 前调
+  `drop_poisoned_api_keys()` 就地摘除（**时机关键**——`build_from_environment` 在调用期才 `safe_load_dotenv`）。
+  **只删空/纯空白的 `*_API_KEY`，绝不注入或读取任何真 key**——守「脚本零 LLM、wrapper 不持 API key」不变量，
+  与本接缝已有的 `stdin=DEVNULL` 同类（喂给子进程前的环境清洗）。**已实测**：摘掉毒值后 agentao 自己的
+  dotenv 加载即恢复正常（`safe_load_dotenv` → 真 key，`discover_llm_kwargs` → 真 key）。测试见
+  `tests/test_runtime.py`（只删空值不删真值 / 子进程 env 实际内容 / 就地摘除幂等 / API 只回变量名不泄值）与
+  `tests/test_web.py`（断言摘除**早于** `build_from_environment`）。
+  > 注：根因在 agentao，已另提 [agentao#157](https://github.com/jin-bo/agentao/pull/157) 修 `safe_load_dotenv`；
+  > 但观澜这层清洗**不依赖那个修复**——它对任何 agentao 版本都生效，故不锁 agentao 下限。
+  > 另更正 backlog note §2 的处方：只改 agentao `discover_llm_kwargs` 跳过空值**不足以**修复（那只是把
+  > `api_key=''` 变成缺省，真 key 仍因掩蔽而永不加载），必须在加载器或调用方摘掉毒值。
+
 - **`wiki/` 与 `.trash/` 的确定性写全部走原子覆盖，消除半写坏页（源自 OpenKB 反向评审 §2，见
   [`docs/backlog/notes/openkb-2026-07-反向评审.md`](docs/backlog/notes/openkb-2026-07-反向评审.md)）** ——
   此前 `wiki/` 的零 LLM 写用裸 `Path.write_text`/`write_bytes`：进程中断 / 磁盘满卡在写一半，会把

--- a/guanlan/runtime.py
+++ b/guanlan/runtime.py
@@ -16,6 +16,7 @@ stdout 是 `RunResult` JSON 信封；字段名是 `error.type`（非 `error.kind
 from __future__ import annotations
 
 import json
+import os
 import subprocess
 import sys
 import threading
@@ -118,6 +119,55 @@ def _progress_heartbeat(working_directory: Path):
             print(file=sys.stderr, flush=True)
 
 
+# ───────── 空 API key 撞空清洗（源自 gbrain v0.42.58 反向评审 §2，探针 gbrain #1249）─────────
+
+_POISON_SUFFIX = "_API_KEY"
+
+
+def _is_poisoned_key(name: str, value: str) -> bool:
+    """`*_API_KEY` 且值为空 / 纯空白 → 毒值。空 key 永不承载语义，留着只会盖住真值。"""
+    return name.endswith(_POISON_SUFFIX) and not value.strip()
+
+
+def poisoned_api_key_names(env: dict[str, str] | None = None) -> list[str]:
+    """列出环境里的毒空 `*_API_KEY` 变量名（不返回任何值——守「wrapper 不持 API key」）。"""
+    items = os.environ if env is None else env
+    return sorted(k for k, v in items.items() if _is_poisoned_key(k, v))
+
+
+def scrubbed_environ() -> dict[str, str]:
+    """`os.environ` 的副本，剔除毒空 `*_API_KEY`——喂给 `agentao run` 子进程用。
+
+    **为什么需要**：Claude Code 会给子进程注入 `ANTHROPIC_API_KEY=''` 以掐断子进程的 LLM 调用。
+    agentao 侧两处叠加把这个空串变成硬失败：① `embedding/factory.py` 收 key 只判 `is not None`
+    （空串照收进 `api_key`，与它自己 docstring 声称的「空/纯空白视作未设」相矛盾）；②
+    `_env.py:safe_load_dotenv` 用 `os.environ.setdefault`（no-override），故 `.env` 里的**真** key
+    盖不进已被注入空串的变量。于是「provider=Anthropic + 从 Claude Code 会话里跑 guanlan」时，
+    `.env` 明明有真 key 却报无 key/空 key（gbrain #1249 同款，本仓 issue 面已实测成立）。
+
+    剔掉毒空值后，agentao 自己的 `safe_load_dotenv` 就能把 `.env` 里的真 key 正常 `setdefault` 进去
+    ——**修复靠的是让 agentao 恢复正常发现，不是我们去读 key**。
+
+    **硬约束**：只删空串、**绝不注入或读取任何真 key**（守「脚本零 LLM、wrapper 不持 API key」不变量
+    ——删一个毒空值 ≠ 持钥）。与本接缝已有的 `stdin=DEVNULL` 同类：都是「喂给子进程前的环境清洗」。
+    """
+    return {k: v for k, v in os.environ.items() if not _is_poisoned_key(k, v)}
+
+
+def drop_poisoned_api_keys() -> list[str]:
+    """就地从 `os.environ` 摘掉毒空 `*_API_KEY`，返回被摘的变量名（供日志/测试）。
+
+    进程内嵌入路径（Web 聊天的 `chat.build_from_environment`）用这支：它直接吃我们自己的
+    `os.environ`，没有子进程边界可以换 env。**摘除时机必须早于** `build_from_environment`
+    ——后者在**调用期**才 `safe_load_dotenv()`，故先摘掉空串，真 key 才 setdefault 得进来。
+    幂等；只删空值故无需恢复（毒值本身无意义）。理由与边界见 `scrubbed_environ`。
+    """
+    dropped = poisoned_api_key_names()
+    for name in dropped:
+        os.environ.pop(name, None)
+    return dropped
+
+
 def _subprocess_runner(
     prompt: str,
     *,
@@ -165,6 +215,8 @@ def _subprocess_runner(
                 # 我们总是显式传 --prompt；切断继承的 stdin，否则父进程被管道/重定向喂 stdin 时，
                 # agentao 会把管道 stdin 当成 run spec，与 --prompt 冲突而拒绝执行（破坏自动化场景）。
                 stdin=subprocess.DEVNULL,
+                # 显式传 env（不再裸继承）：只为剔除毒空 `*_API_KEY`，其余逐项照传（见 scrubbed_environ）。
+                env=scrubbed_environ(),
             )
     except OSError as exc:
         # agentao 不在 PATH（或无法启动子进程）：归一为运行时错误，遵守退出码契约，

--- a/guanlan/web/conversation.py
+++ b/guanlan/web/conversation.py
@@ -25,6 +25,7 @@ from agentao.permissions import PermissionMode
 from agentao.tools.goal import UpdateGoalTool
 
 from ..gate import REPAIR_PROMPT, _render_violations
+from ..runtime import drop_poisoned_api_keys
 from ..search import CorpusCache
 from ..skill import SKILL_NAME
 from .chat_support import (
@@ -241,6 +242,10 @@ class Conversation:
                 make_guanlan_search_tool(search_cache, wiki=kb / "wiki")
             ]
 
+        # 进程内嵌入路径没有子进程边界可换 env，故就地摘掉毒空 `*_API_KEY`（gbrain 反向评审 §2）：
+        # `build_from_environment` 在**调用期**才 `safe_load_dotenv()`，先摘空串，`.env` 里的真 key
+        # 才 setdefault 得进来。只删空值、绝不读写真 key（守「wrapper 不持 API key」）。
+        drop_poisoned_api_keys()
         self.agent = chat.build_from_environment(**opts)
         # 姿态两点同步置位（缺第二步 = 没真正切换，照搬 cli/run.py）：开局用构造姿态。
         self._apply_mode(mode)

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -1,9 +1,17 @@
-"""P2 runtime 测试：RunResult 信封解析 + agentao 不在 PATH 的兜底（不打真实 LLM）。"""
+"""P2 runtime 测试：RunResult 信封解析 + agentao 不在 PATH 的兜底 + 空 API key 撞空清洗
+（不打真实 LLM）。"""
 
+import os
 import subprocess
 from pathlib import Path
 
-from guanlan.runtime import _parse_envelope, run_agent_task
+from guanlan.runtime import (
+    _parse_envelope,
+    drop_poisoned_api_keys,
+    poisoned_api_key_names,
+    run_agent_task,
+    scrubbed_environ,
+)
 
 
 def test_parse_envelope_ok():
@@ -62,3 +70,67 @@ def test_missing_agentao_executable_is_runtime_error(tmp_path: Path, monkeypatch
     assert not r.ok
     assert r.error_type == "runtime_error"
     assert "PATH" in r.final_text
+
+
+# ───────── 空 API key 撞空清洗（gbrain v0.42.58 反向评审 §2，探针 gbrain #1249）─────────
+
+
+def test_scrubbed_environ_drops_empty_api_keys_only(monkeypatch):
+    """只剔除**空/纯空白**的 `*_API_KEY`；真值、其他空变量、同名非 key 变量一律照传。"""
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "")  # Claude Code 注入的毒值
+    monkeypatch.setenv("OPENAI_API_KEY", "   ")  # 纯空白同样是毒值
+    monkeypatch.setenv("DEEPSEEK_API_KEY", "sk-real")  # 真值必须留下
+    monkeypatch.setenv("SOME_OTHER_VAR", "")  # 空但不是 API key → 不管
+    monkeypatch.setenv("ANTHROPIC_BASE_URL", "")  # 空但不是 `_API_KEY` 后缀 → 不管
+
+    env = scrubbed_environ()
+    assert "ANTHROPIC_API_KEY" not in env
+    assert "OPENAI_API_KEY" not in env
+    assert env["DEEPSEEK_API_KEY"] == "sk-real"
+    assert env["SOME_OTHER_VAR"] == ""
+    assert env["ANTHROPIC_BASE_URL"] == ""
+    # 不动 os.environ（子进程路径换的是传给子进程的副本）。
+    assert os.environ["ANTHROPIC_API_KEY"] == ""
+
+
+def test_subprocess_runner_passes_scrubbed_env(tmp_path: Path, monkeypatch):
+    """`agentao run` 子进程拿到的 env **不含**毒空 key、但含真 key 与其余变量（不再裸继承）。"""
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "")
+    monkeypatch.setenv("DEEPSEEK_API_KEY", "sk-real")
+    monkeypatch.setenv("PATH", os.environ.get("PATH", ""))
+    captured: dict = {}
+
+    def fake_run(cmd, **kwargs):
+        captured.update(kwargs)
+        return subprocess.CompletedProcess(cmd, 0, '{"status":"ok","final_text":"x"}', "")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    r = run_agent_task("q", working_directory=tmp_path, skills=())
+
+    assert r.ok
+    env = captured["env"]
+    assert "ANTHROPIC_API_KEY" not in env  # 毒值没进子进程
+    assert env["DEEPSEEK_API_KEY"] == "sk-real"  # 真值照传
+    assert env.get("PATH")  # 其余环境完整继承（否则 agentao 都找不到）
+    assert captured["stdin"] is subprocess.DEVNULL  # 既有姿态不受影响
+
+
+def test_drop_poisoned_api_keys_is_in_place_and_idempotent(monkeypatch):
+    """进程内路径：就地摘除、返回被摘名字、重复调用安全（Web 每建会话都会走一次）。"""
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "")
+    monkeypatch.setenv("DEEPSEEK_API_KEY", "sk-real")
+
+    assert poisoned_api_key_names() == ["ANTHROPIC_API_KEY"]
+    assert drop_poisoned_api_keys() == ["ANTHROPIC_API_KEY"]
+    assert "ANTHROPIC_API_KEY" not in os.environ
+    assert os.environ["DEEPSEEK_API_KEY"] == "sk-real"  # 真值不受影响
+    assert drop_poisoned_api_keys() == []  # 幂等：第二次无可摘
+
+
+def test_poisoned_names_never_expose_values(monkeypatch):
+    """守「wrapper 不持 API key」：清洗 API 只回**变量名**，任何返回值里都不出现真 key 字样。"""
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "")
+    monkeypatch.setenv("DEEPSEEK_API_KEY", "sk-must-not-leak")
+
+    assert "sk-must-not-leak" not in str(poisoned_api_key_names())
+    assert "sk-must-not-leak" not in str(drop_poisoned_api_keys())

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -7,6 +7,7 @@
 import asyncio
 import base64
 import json
+import os
 import re
 import socket
 import sys
@@ -2212,6 +2213,36 @@ def _chat_with(client, message, attachments):
                 elif event == "error":
                     error = data
     return tokens, done, error
+
+
+def test_chat_scrubs_poisoned_api_key_before_build(kb, monkeypatch) -> None:
+    """进程内嵌入路径：`build_from_environment` 被调用时，毒空 `*_API_KEY` **已从 os.environ 摘除**
+    （gbrain v0.42.58 反向评审 §2）。
+
+    Claude Code 给子进程注入 `ANTHROPIC_API_KEY=''`，而 agentao 的 `safe_load_dotenv` 用 `setdefault`
+    ——空串不摘掉，`.env` 里的真 key 就永远 setdefault 不进来，Web 问答报「无 key」。断言时机而非仅结果：
+    摘除必须**早于** `build_from_environment`（它在调用期才 load dotenv）。
+    """
+    import guanlan.web.chat as chat_mod
+
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "")
+    monkeypatch.setenv("DEEPSEEK_API_KEY", "sk-real")
+    monkeypatch.setattr(chat_mod, "ensure_skill_available", lambda _kb: None)
+    seen: dict = {}
+
+    def fake_bfe(**kwargs):
+        seen["anthropic"] = os.environ.get("ANTHROPIC_API_KEY", "<已摘除>")
+        seen["deepseek"] = os.environ.get("DEEPSEEK_API_KEY")
+        return _FakeAgent(kwargs)
+
+    monkeypatch.setattr(chat_mod, "build_from_environment", fake_bfe)
+
+    with TestClient(create_app(kb)) as c:
+        _tokens, done, error = _chat(c, "问题")
+
+    assert error is None and done is not None
+    assert seen["anthropic"] == "<已摘除>"  # 毒值在建 agent 之前就没了
+    assert seen["deepseek"] == "sk-real"  # 真值不受影响
 
 
 def test_chat_emits_heartbeat_during_silence(kb, monkeypatch) -> None:


### PR DESCRIPTION
> ⚠️ **栈式 PR**：base 是 `chore/v0.1.18-release-prep`（#33），因为两者都动 CHANGELOG。#33 合并后本 PR 会自动改指 main。

源自 gbrain v0.42.58 反向评审 §2（探针 gbrain #1249）。发版前复核确认**该缺陷仍然活着**，且咬的正是「在 Claude Code 里开发/运行观澜」这一主场景。

## 故障链（已实测复现，不是推断）

Claude Code 给子进程注入 `ANTHROPIC_API_KEY=''` 以掐断子进程的 LLM 调用。agentao 的 `safe_load_dotenv` 用 `os.environ.setdefault`（no-override）——**空串也算「已设置」**，于是 `.env` 里的真 key 永远 setdefault 不进来：

```python
os.environ["ANTHROPIC_API_KEY"] = ""
safe_load_dotenv(".env")            # .env 里有 ANTHROPIC_API_KEY=sk-real
os.getenv("ANTHROPIC_API_KEY")      # -> ''          (被掩蔽)
discover_llm_kwargs()["api_key"]    # -> ''          (继续往下传)

os.environ.pop("ANTHROPIC_API_KEY") # 摘掉毒值后走同一条路
safe_load_dotenv(".env")            # -> 'sk-real'   (恢复正常)
```

触发面精确：**provider = Anthropic 且从 Claude Code 会话里跑 guanlan**。OpenAI provider 不受影响（Claude Code 不注入 `OPENAI_API_KEY=''`）。

## 改动

两条 LLM 路径在交给 agentao **之前**剔除毒空值，新原语收在 `runtime.py`（agentao 接缝）：

| 路径 | 做法 |
|---|---|
| CLI 子进程 | `_subprocess_runner` 显式传 `env=scrubbed_environ()`（不再裸继承父环境） |
| Web 进程内嵌入 | `chat.build_from_environment` 前调 `drop_poisoned_api_keys()` 就地摘除 |

**时机是关键**：`build_from_environment` 在**调用期**才 `safe_load_dotenv()`，先摘空串，真 key 才 setdefault 得进来。

**硬约束**：只删空/纯空白的 `*_API_KEY`，**绝不注入或读取任何真 key**——守「脚本零 LLM、wrapper 不持 API key」不变量。清洗 API 只回**变量名**不回值，且有测试钉住返回值里不出现真 key 字样。与本接缝已有的 `stdin=DEVNULL` 同类（喂给子进程前的环境清洗），有先例。

## 两处对 backlog note 处方的更正（实测得出）

1. note 称 agentao `factory.py` 收 key 只判 `is not None`「与它自己 88–90 行 docstring 直接矛盾」——**不成立**。那句 docstring 讲的是 `LLM_EXTRA_BODY`（它确实实现了 `.strip()` 跳过），不覆盖 `{PROVIDER}_API_KEY`。缺陷是真的，但不是文档与实现打架。
2. note 的首选修法「改 agentao `factory.py` 一行跳过空值」**不足以修复**：那只把 `api_key=''` 变成缺省，真 key 仍因掩蔽而永不加载。根因在加载器（`setdefault`），已另提 [agentao#157](https://github.com/jin-bo/agentao/pull/157)。

**但观澜这层清洗不依赖那个修复**——它对任何 agentao 版本都生效，故本次**不锁 agentao 下限**。

## 测试

- `tests/test_runtime.py` 4 例：只删空值不删真值（且不动 `os.environ`）· 子进程实收 env 的内容（含真值与 PATH、不含毒值、`stdin=DEVNULL` 姿态不变）· 就地摘除幂等 · 清洗 API 不泄露真 key
- `tests/test_web.py` 1 例：断言摘除**早于** `build_from_environment`

两处清洗各自变异撤掉后对应用例即红。全套 **1146 passed / 1 skipped**，`uvx ruff check` clean。

🤖 Generated with [Claude Code](https://claude.com/claude-code)