### PR TITLE
chore(release): 定版 0.1.18 —— MCP 底座迁 SDK v2 + 三条反向评审补强

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,13 @@
 本项目所有显著变更记录于此。格式参考 [Keep a Changelog](https://keepachangelog.com/zh-CN/1.1.0/)，
 版本号遵循 [语义化版本](https://semver.org/lang/zh-CN/)。版本号单一来源为 `guanlan/__init__.py`。
 
-## [未发布]
+## [0.1.18] - 2026-07-30
+
+一次**底座迁移 + 反向评审补强**的发布：① **MCP 宿主迁到官方 SDK v2 / 协议 `2026-07-28`**（P4.18，
+等价迁移——命令契约与工具集逐字保留，代价是 `[mcp]` extra 的安装面破坏性变更）；② 三条源自兄弟项目
+反向评审的确定性补强/修复——ingest 撞名守卫（llm_wiki）、`wiki/`·`.trash/` 写走原子覆盖（OpenKB）、
+交给 agentao 前剔除毒空 `*_API_KEY`（gbrain）；③ 检索收敛提示与一批文档校正。不新增退出码、不动门禁、
+`raw/` 只读不破。
 
 ### 新增
 
@@ -87,6 +93,13 @@
     SDK 接管 fd 1 **之前**那段窗口（`require_kb_root`/P5.4 预热/`build_mcp`/argparse），也正是我们自己的代码
     可能泄漏处。原先"在真传输上实证 OTel 不污染 stdout"的说法说过头了，已按实测改写（决策P4.18-6）。
   - `tests/test_mcp.py` 63 例、全套 1141 通过 / 1 skip。
+
+### 文档
+
+- `CLAUDE.md` 优化：status 段瘦身、过时事实校正、命令清单补全。
+- 发版前收口：`docs/发布到-PyPI.md` 改按「版本单一源在 `guanlan/__init__.py`」重写实操步骤（并补两-PR
+  仪式、CHANGELOG 段头格式、tag 落点、发布后验证的缓存坑）；归档 gbrain / llm_wiki / swarmvault 三份
+  反向评审笔记；校正 `README.en.md` 与 `DESIGN.md` §7 中与 P4.18 不一致的口径。
 
 ### 修复
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 观澜 (GuānLán) is an implementation of the [Karpathy LLM Wiki pattern](https://gist.github.com/karpathy/442a6bf555914893e9891c11519de94f): an Agent incrementally builds and maintains a structured, cross-linked markdown knowledge wiki instead of doing fresh RAG retrieval on every query. The full design (in Chinese) is the authoritative spec — read [`docs/DESIGN.md`](docs/DESIGN.md) before any non-trivial change.
 
-**Current status:** released through v0.1.17; the roadmap is fully implemented — P2 minimal closed loop, P3 health/graph family, P4 optional host layer (Web + MCP, through P4.17's Streamable HTTP transport and P4.18's move to MCP SDK v2 / protocol `2026-07-28`), P5 retrieval + multi-format ingest, and every half-phase P2.1–P5.4. No roadmap spec remains unimplemented; per-phase flags, behavior, and red lines live in the `docs/P*.md` file for that phase, not here.
+**Current status:** released through v0.1.18; the roadmap is fully implemented — P2 minimal closed loop, P3 health/graph family, P4 optional host layer (Web + MCP, through P4.17's Streamable HTTP transport and P4.18's move to MCP SDK v2 / protocol `2026-07-28`), P5 retrieval + multi-format ingest, and every half-phase P2.1–P5.4. No roadmap spec remains unimplemented; per-phase flags, behavior, and red lines live in the `docs/P*.md` file for that phase, not here.
 
 CLAUDE.md does **not** restate phase history or per-decision detail — authoritative sources:
 - Per-version change detail → [`CHANGELOG.md`](CHANGELOG.md)

--- a/guanlan/__init__.py
+++ b/guanlan/__init__.py
@@ -4,4 +4,4 @@ P1 交付 `guanlan init`（确定性生成最小模板）。ingest / query 等 L
 由 `guanlan-wiki` skill 驱动 Agentao 完成；本包只做编排与确定性门禁。
 """
 
-__version__ = "0.1.18.dev0"
+__version__ = "0.1.18"


### PR DESCRIPTION
两-PR 仪式的第一个：**定版**。合并后 tag 打在**合并后的 main 提交**上触发 `release.yml`。

## 改动（三处，零代码逻辑改动）

| 文件 | 改动 |
|---|---|
| `CHANGELOG.md` | `## [未发布]` → `## [0.1.18] - 2026-07-30` + 版本导语；新增 `### 文档` 小节 |
| `guanlan/__init__.py` | `0.1.18.dev0` → `0.1.18`（版本单一来源） |
| `CLAUDE.md` | status 行 `released through v0.1.17` → `v0.1.18` |

新增的 `### 文档` 小节收编本周期两个纯文档 PR（#28 CLAUDE.md 优化、#33 发版前收口）——此前它们在 CHANGELOG 里没有落点。

## 对账

逐条比对 `git log v0.1.17..HEAD` 与 CHANGELOG `[未发布]`。**这一步是特意做的**——上一轮正是这么揪出 #31 被整个漏记的。八个提交全部有归属：

| 提交 | 归属 |
|---|---|
| #35 空 env 撞空 | 修复 |
| #33 发版前收口 | 文档（本次补） |
| #32 P4.18 MCP 2.0 迁移 | 变更 |
| #31 `.trash` 原子写 | 修复（#33 补记，此前漏） |
| #30 ingest 守卫收敛 | 折进「新增」条目（该条已述三轮 code-review 收敛） |
| #29 ingest 守卫 + 检索提示 | 新增 + 优化 |
| #28 CLAUDE.md 优化 | 文档（本次补） |
| #27 进入开发态 | 版本管理机械步骤，按惯例不记 |

## 验证

- **用 `release.yml` 里逐字相同的 awk 干跑了一遍 notes 抽取**：命中 `## [0.1.18]` 段、135 行、在 `## [0.1.17]` 前正确收尾——GitHub Release 页不会退化成占位链接。
- `uv build` 双产物为 `guanlan_wiki-0.1.18`；`guanlan --version` → `0.1.18`。
- 全套 **1146 passed / 1 skipped**，`uvx ruff check` clean。
- 测试无硬编码版本断言（`test_mcp.py` 的 `serverInfo` 断言取 `__version__` 常量，随定版自动跟随）。

## 合并之后

1. `git checkout main && git pull`
2. `git tag -a v0.1.18 -m v0.1.18 && git push origin v0.1.18` —— tag **必须打在合并后的 main 提交上**
3. 流水线产 **两样**：PyPI 发布 + 自动建 GitHub Release（光推 tag 不会自己有 Release 页）
4. 再开**回开发态 PR**：只改 `__version__` → `0.1.19.dev0` 一行，CHANGELOG 不动

🤖 Generated with [Claude Code](https://claude.com/claude-code)