### PR TITLE
chore: 回开发态 0.1.18 → 0.1.19.dev0

### DIFF
--- a/guanlan/__init__.py
+++ b/guanlan/__init__.py
@@ -4,4 +4,4 @@ P1 交付 `guanlan init`（确定性生成最小模板）。ingest / query 等 L
 由 `guanlan-wiki` skill 驱动 Agentao 完成；本包只做编排与确定性门禁。
 """
 
-__version__ = "0.1.18"
+__version__ = "0.1.19.dev0"


### PR DESCRIPTION
两-PR 发版仪式的第二步（第一步是 #36 定版）。**只改一行**：`guanlan/__init__.py:__version__` → `0.1.19.dev0`。

## v0.1.18 已发布，落地情况

| 项 | 结果 |
|---|---|
| tag | `v0.1.18` → 合并后的 main 提交 `aa9582a`（不是 PR 分支） |
| 流水线 | run `30555968995`：`pypi-publish=success` / `github-release=success` |
| PyPI | `guanlan_wiki-0.1.18-py3-none-any.whl` + `.tar.gz`，JSON API latest = 0.1.18 |
| GitHub Release | v0.1.18，非 draft/非 pre，notes 138 行（从 CHANGELOG 版本段抽取，**未**退化成占位链接） |
| 隔离 venv 复装 | `--no-cache-dir` 钉 `==0.1.18` → `guanlan --version` = 0.1.18；init/check/health 冒烟通过；依赖解析到 `agentao 0.4.18`（满足本版抬到的 `>=0.4.17` 下限） |

## 为什么 CHANGELOG 不动

不预建空的 `## [未发布]` 段——下一个变更落地时随那个 PR 一起加。段头不会长期空着，也避免 `release.yml` 的 awk 将来抽到一个空段。

🤖 Generated with [Claude Code](https://claude.com/claude-code)