### PR TITLE
chore: 回开发态 0.1.19 → 0.1.20.dev0 (两-PR 发版仪式第二步)

### DIFF
--- a/guanlan/__init__.py
+++ b/guanlan/__init__.py
@@ -4,4 +4,4 @@ P1 交付 `guanlan init`（确定性生成最小模板）。ingest / query 等 L
 由 `guanlan-wiki` skill 驱动 Agentao 完成；本包只做编排与确定性门禁。
 """
 
-__version__ = "0.1.19"
+__version__ = "0.1.20.dev0"


### PR DESCRIPTION
两-PR 发版仪式**第二步**。只改 `guanlan/__init__.py` 的 `__version__` 一行。

**CHANGELOG 刻意不动**——`## [未发布]` 段等下一个变更落地时再加，不预建空壳：预建的空段会被 `release.yml` 抽 notes 的 awk 扫进下一版的 Release notes。

## v0.1.19 落地核对

| 项 | 结果 |
|---|---|
| tag | `v0.1.19` → 打在合并后的 main 提交 `ae67a18` |
| 流水线 | `Release (PyPI)` run 30607350891 · success |
| PyPI | `guanlan_wiki-0.1.19-py3-none-any.whl` + `.tar.gz`，均带 publish attestation |
| GitHub Release | 非草稿，notes 90 行（awk 抽 `^## \[0.1.19\]` 段，本地已预演 87 行正文） |
| 隔离 venv 装回 | Python 3.12 + `--no-cache-dir` + 钉 `==0.1.19` → `guanlan 0.1.19` |
| 冒烟 | `init` / `check` / `health` 全 exit 0 |
| **本版修复端到端复核** | 全 CRLF 的库跑 `reindex --prune`：CRLF 25 → 26、落单 LF 恒为 **0**；四段模板提示注释完好 |

顺带记一个踩坑，免得下次误判：第一次装回报 `No matching distribution found`，看着像 PyPI `/simple` 索引滞后（历史上确实有这个坑），实际是 `/usr/bin/python3` 是 **3.9.6**，而本项目 `requires-python = ">=3.10"`——pip 拒得对。换 3.12 即通过。**验证用的解释器版本要先确认，别把环境问题读成发布问题。**

🤖 Generated with [Claude Code](https://claude.com/claude-code)