### PR TITLE
chore: 回开发态 0.1.20 → 0.1.21.dev0 (两-PR 发版仪式第二步)

### DIFF
--- a/guanlan/__init__.py
+++ b/guanlan/__init__.py
@@ -4,4 +4,4 @@ P1 交付 `guanlan init`（确定性生成最小模板）。ingest / query 等 L
 由 `guanlan-wiki` skill 驱动 Agentao 完成；本包只做编排与确定性门禁。
 """
 
-__version__ = "0.1.20"
+__version__ = "0.1.21.dev0"


### PR DESCRIPTION
两-PR 发版仪式**第二步**，紧随 #44（定版）与 `v0.1.20` tag。

**只改一行**：`guanlan/__init__.py:__version__` `0.1.20` → `0.1.21.dev0`。

**CHANGELOG 刻意不动**——`## [未发布]` 段等下一个变更落地再加。现在就摆一个空段落，只会让 `release.yml` 的 notes 抽取多一个可撞的目标。

## v0.1.20 发布结果（已验证）

| 产物 | 状态 |
|---|---|
| `Release (PyPI)` 流水线 | success（run `30698088103`） |
| PyPI | `latest = 0.1.20`，`guanlan_wiki-0.1.20-py3-none-any.whl` + `.tar.gz` |
| GitHub Release | [v0.1.20](https://github.com/jin-bo/guanlan/releases/tag/v0.1.20)，notes 48 行**真正文**（不是占位链接） |
| 隔离 venv 验证 | `uv pip install --no-cache 'guanlan-wiki[web,mcp]==0.1.20'` → `guanlan 0.1.20`；`guanlan/web/mcpdiag.py` 随包到位，端点与错误脱敏行为实测正常 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)