### PR TITLE
chore: 回开发态 0.1.21 → 0.1.22.dev0 (两-PR 发版仪式第二步)

### DIFF
--- a/guanlan/__init__.py
+++ b/guanlan/__init__.py
@@ -4,4 +4,4 @@ P1 交付 `guanlan init`（确定性生成最小模板）。ingest / query 等 L
 由 `guanlan-wiki` skill 驱动 Agentao 完成；本包只做编排与确定性门禁。
 """
 
-__version__ = "0.1.21"
+__version__ = "0.1.22.dev0"


### PR DESCRIPTION
两-PR 发版仪式的**第二步**。v0.1.21 已发布（tag 打在 `f70f320`，`release.yml` 成功，PyPI + GitHub Release 均已产出）。

只改**一行**：`guanlan/__init__.py` 的 `__version__` `0.1.21` → `0.1.22.dev0`。

CHANGELOG **不动** —— `[未发布]` 段等下一个变更落地再加（沿 #45 / #19 / #15 的惯例）。

全量 1231 passed / 1 skipped。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
