### PR TITLE
fix: agentao JSON 信封两端钉死 UTF-8——修 Windows 中文 locale 下 ingest/query 解码失败 (#50)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,32 @@
 
 ### 修复
 
+- **Windows 中文 locale（CP936）下解不动 agentao 的 JSON 信封**（issue #50，与本次 IM 主题无关的
+  独立修复）——`agentao run --format json` 的 stdout 此前**两端都没约定编码、各自跟 locale 走**，
+  只在「父子 locale 恰好一致」时侥幸成立。Windows 上 agentao 自己强制 UTF-8 输出、观澜却按 CP936
+  解码，于是失配。现在**两端一起钉死 UTF-8**：父端 `encoding="utf-8"`，子端经 `PYTHONIOENCODING`
+  （不是 `PYTHONUTF8`——后者连 fsencoding 一起改，血溅面远大于这条协议缝）。
+  - **崩溃只是少数派**：报告里那条 `UnicodeDecodeError` 约占三分之一，另外约三分之二是**中文信封
+    被静默解成乱码、`json.loads` 照样成功**——JSON 骨架全是 ASCII、撑得住，死的只有中文正文。
+    也就是说 `query` 会以**退出码 0 交付一段乱码答案**，而这一半从来不会被谁注意到。
+  - **只钉一端会换个 locale 继续错**：单钉父端修好 Windows、却打断 POSIX 的 matched-locale
+    （`LANG=zh_CN.GBK` 下子端仍按 GBK 发）。`convert.py` 已经踩过这个坑并回退过一次
+    （backlog §1.③/§2.4b：「须两端协同」），这次不重蹈。**`convert.py` 本次不动**——那条缝的对端
+    是裸 `print` 的 skill 脚本，与本接缝不同构。
+  - **`errors="replace"` 不是懒惰档、是 Windows 上唯一可控的档**：`capture_output` 在 Windows 走
+    reader 线程，strict 解码抛的异常**死在 subprocess 内部线程里**，父进程 `try/except` 根本够不着
+    ——「保持 strict、捕获 `UnicodeDecodeError`」这条路走不通，只会再次拿到 `proc.stdout is None`。
+  - 连带把 `_parse_envelope` 的 `stdout`/`stderr` 归一为 `str | None`：读不到 stdout 时给一句人话
+    诊断，而不是 `json.loads(None)` 抛个 `TypeError` 把真因盖掉。**这只是错误呈现层的兜底**，
+    真修是上面的编码契约——留着它是因为「读不到 stdout」不止编码一种成因。
+  - 顺带说明这条缝的影响面：它是**所有** LLM 命令的唯一入口（`ingest`/`query`/`heal`/`audit`、
+    Web 作业、MCP 的 `query` 工具）。且异常路径会**绕过写门禁**——`run_agent_task` 抛异常时
+    `enforce_write_result` 根本不执行，那次运行的 `raw/` 只读快照比对一条都没跑。
+  - 回归测试三层：契约测试（父端 `encoding`/`errors` + 子端 `PYTHONIOENCODING` 成对断言，
+    跨平台常绿）、`_parse_envelope(None, None)` 单测、以及一条**真管道**用例——在
+    `LC_ALL=C` + `-X utf8=0` 的真子解释器里跑（父端 locale 编码 = ASCII，与 Windows CP936 同构），
+    PATH 上摆一个只吐 UTF-8 字节的假 agentao。进程内 monkeypatch 造不出这个缺陷（locale 解码档在
+    解释器启动时就定了），故必须真起进程；造不出非 UTF-8 父端的环境**诚实跳过**、不静默空跑。
 - **`guanlan im-login --platform weixin` 拿不到二维码**——真机首跑即挂，服务端回
   `{"err_msg":"missing bot_type","ret":1}`。三处修正（详见 `docs/P4.21-IM宿主.md` §7.6 实测表）：
   - `bot_type` 是 **query 参数**、不是请求体字段（放 body 里服务端读不到，照样报 missing），

--- a/guanlan/runtime.py
+++ b/guanlan/runtime.py
@@ -9,7 +9,8 @@ wrapper 以工作目录 = 知识库根调用：
                 --interaction-policy reject \
                 [--model M] [--max-iterations N]
 
-stdout 是 `RunResult` JSON 信封；字段名是 `error.type`（非 `error.kind`）。
+stdout 是 `RunResult` JSON 信封；字段名是 `error.type`（非 `error.kind`）。信封的编码是
+**协议的一部分、固定 UTF-8**，父子两端都显式钉死、不随 locale 变（issue #50，见 `envelope_child_env`）。
 `runner` 可注入以便测试——fake runner 模拟"写 wiki + 返回摘要"，不起子进程、不打真实 LLM。
 """
 
@@ -154,6 +155,54 @@ def scrubbed_environ() -> dict[str, str]:
     return {k: v for k, v in os.environ.items() if not _is_poisoned_key(k, v)}
 
 
+# ───────── 信封编码契约（issue #50：Windows GBK locale 下解码 agentao 输出失败）─────────
+
+ENVELOPE_ENCODING = "utf-8"
+# 管道解码用**非严格**档，理由见 `envelope_child_env` 末段——这不是「怕出错就 replace」的懒惰档，
+# 是 Windows 上唯一可控的档：strict 的 UnicodeDecodeError 死在 subprocess 自己的 reader 线程里。
+ENVELOPE_ERRORS = "replace"
+
+
+def envelope_child_env() -> dict[str, str]:
+    """喂给 `agentao run` 的环境：`scrubbed_environ()` 之上再**显式钉死子进程 std 流编码为 UTF-8**。
+
+    **为什么需要**（issue #50）：`--format json` 的 stdout 信封是**机器协议**，两端必须约定同一个
+    编码；此前两端都没约定，各自跟 locale 走，于是只在「父子 locale 恰好一致」时侥幸成立：
+
+    | 环境 | 子端（agentao）实际编码 | 父端（`text=True`）解码 | 结果 |
+    |---|---|---|---|
+    | Windows + CP936 | **UTF-8**（agentao `_ensure_utf8()` 只在 win32 强制） | GBK（locale） | ❌ 失配 |
+    | POSIX + UTF-8 locale | UTF-8 | UTF-8 | ✅ CI 只覆盖这一格 |
+    | POSIX + `LANG=zh_CN.GBK` | GBK（locale） | GBK（locale） | ✅ matched-locale 侥幸 |
+
+    失配那格有**两种**表现，崩溃反而是少数派：中文信封的 UTF-8 字节按 GBK 解，约 1/3 撞上非法序列
+    （报告里那条 `UnicodeDecodeError`），另约 2/3 **静默解成乱码且 `json.loads` 照样成功**——
+    JSON 骨架全是 ASCII、撑得住，死的只有中文正文。于是 `query` 会以退出码 0 交付一段乱码答案。
+
+    **为什么必须两端一起钉**：只钉父端 `encoding="utf-8"` 会修好 Windows 那格、却打断 POSIX
+    matched-locale 那格（子端仍按 GBK 发、父端强解 UTF-8 → 乱码）。这个坑 `convert.py` 已经踩过
+    一次并回退，见 docs/backlog/notes/gbrain-v0.42.53-反向审计-guanlan缺陷.md §1.③/§2.4b：
+    「须两端协同」。本接缝比 convert 那条好办——对端是 agentao 而非裸 `print` 的 skill 脚本，
+    一个环境变量就钉得住。
+
+    **为什么是 `PYTHONIOENCODING` 而不是 `PYTHONUTF8=1`**：后者连 fsencoding（argv/文件名口径）
+    一起改，会波及 agentao 对磁盘上非 UTF-8 文件名的读写，血溅面远大于这条协议缝；
+    `PYTHONIOENCODING` 只动 std 流，正是要的粒度。用户手工设的 `PYTHONIOENCODING=cp936` 会被
+    **覆盖**（非 setdefault）：这条缝是机器协议、不是给人看的控制台，编码不可协商。
+    （agentao 侧 `_ensure_utf8()` 用的正是 `setdefault`，故显式传入与它不冲突、且在 POSIX 上补上了
+    它主动跳过的那一半。）
+
+    **为什么父端还要 `errors="replace"`**：钉死两端后管道里本该只有合法 UTF-8，`replace` 兜的是
+    第三方混入的杂散字节（子进程链上的原生崩溃信息等）。**strict 在 Windows 上不可救**——
+    `capture_output` 在 Windows 走 `_readerthread`，解码异常死在 subprocess 内部线程里，父进程
+    `try/except` 够不着，只会再次拿到 `proc.stdout is None`（issue #50 报告的 traceback 即此形态）。
+    所以「保持 strict、捕获 `UnicodeDecodeError`」这条路在 Windows 上根本走不通。
+    """
+    env = scrubbed_environ()
+    env["PYTHONIOENCODING"] = ENVELOPE_ENCODING
+    return env
+
+
 def drop_poisoned_api_keys() -> list[str]:
     """就地从 `os.environ` 摘掉毒空 `*_API_KEY`，返回被摘的变量名（供日志/测试）。
 
@@ -212,11 +261,17 @@ def _subprocess_runner(
                 cwd=str(working_directory),
                 capture_output=True,
                 text=True,
+                # 信封是机器协议：**不跟 locale 走**，父端解码与子端 std 流（下面 env 里的
+                # PYTHONIOENCODING）一起钉死 UTF-8；errors 非严格档在 Windows 上是硬需求。
+                # 完整理由（含只钉一端为何会回归 POSIX matched-locale）见 `envelope_child_env`。
+                encoding=ENVELOPE_ENCODING,
+                errors=ENVELOPE_ERRORS,
                 # 我们总是显式传 --prompt；切断继承的 stdin，否则父进程被管道/重定向喂 stdin 时，
                 # agentao 会把管道 stdin 当成 run spec，与 --prompt 冲突而拒绝执行（破坏自动化场景）。
                 stdin=subprocess.DEVNULL,
-                # 显式传 env（不再裸继承）：只为剔除毒空 `*_API_KEY`，其余逐项照传（见 scrubbed_environ）。
-                env=scrubbed_environ(),
+                # 显式传 env（不再裸继承）：剔除毒空 `*_API_KEY`（见 scrubbed_environ）+ 钉死子端
+                # std 流编码（见 envelope_child_env），其余逐项照传。
+                env=envelope_child_env(),
             )
     except OSError as exc:
         # agentao 不在 PATH（或无法启动子进程）：归一为运行时错误，遵守退出码契约，
@@ -230,12 +285,28 @@ def _subprocess_runner(
     return _parse_envelope(proc.returncode, proc.stdout, proc.stderr)
 
 
-def _parse_envelope(returncode: int, stdout: str, stderr: str) -> AgentRunResult:
-    """把子进程结果归一为 AgentRunResult。stdout 解析失败 → runtime_error（不可信任为成功）。"""
+def _parse_envelope(
+    returncode: int, stdout: str | None, stderr: str | None
+) -> AgentRunResult:
+    """把子进程结果归一为 AgentRunResult。stdout 解析失败 → runtime_error（不可信任为成功）。
+
+    **`str | None` 不是防御性洁癖**：`capture_output` 在 Windows 用 reader 线程收管道，线程里
+    抛异常（如解码失败）会让 `proc.stdout` 变成 `None`，`json.loads(None)` 再抛一个 `TypeError`
+    把真正的原因盖掉——issue #50 报的就是这条二次异常。此处**只是错误呈现层的兜底**，真修在
+    `envelope_child_env` 的两端编码契约；留着它是因为「读不到 stdout」不止编码一种成因。
+    """
+    stdout_missing = stdout is None  # reader 线程猝死的独有形态，值得单独给一句人话诊断
+    stdout = stdout or ""
+    stderr = stderr or ""
     try:
         data = json.loads(stdout)
-    except (json.JSONDecodeError, ValueError):
-        detail = stderr.strip() or stdout.strip() or "无法解析 agentao run 输出"
+    except (json.JSONDecodeError, ValueError, TypeError):  # TypeError 双保险（上面已归一非 None）
+        fallback = (
+            "未能读到 agentao run 的 stdout（子进程输出流读取失败）"
+            if stdout_missing
+            else "无法解析 agentao run 输出"
+        )
+        detail = stderr.strip() or stdout.strip() or fallback
         return AgentRunResult(False, detail, error_type="runtime_error", raw=None)
     if not isinstance(data, dict):
         return AgentRunResult(False, stdout.strip(), error_type="runtime_error", raw=None)

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -1,13 +1,19 @@
 """P2 runtime 测试：RunResult 信封解析 + agentao 不在 PATH 的兜底 + 空 API key 撞空清洗
-（不打真实 LLM）。"""
++ 信封编码契约（issue #50）（不打真实 LLM）。"""
 
+import json
 import os
 import subprocess
+import sys
 from pathlib import Path
 
+import pytest
+
+import guanlan
 from guanlan.runtime import (
     _parse_envelope,
     drop_poisoned_api_keys,
+    envelope_child_env,
     poisoned_api_key_names,
     run_agent_task,
     scrubbed_environ,
@@ -55,6 +61,22 @@ def test_status_ok_but_llm_api_error_is_failure():
     assert not r.ok
     assert r.error_type == "runtime_error"
     assert "LLM API error" in r.final_text
+
+
+def test_parse_envelope_none_stdout_is_runtime_error():
+    """Windows GBK：reader 线程解码猝死 → `proc.stdout is None` → 必须归一为 runtime_error，
+    而不是 `json.loads(None)` 的裸 TypeError 把真因盖掉（issue #50）。"""
+    r = _parse_envelope(0, None, None)
+    assert not r.ok and r.error_type == "runtime_error"
+    assert "stdout" in r.final_text  # 有可读诊断，不是空串
+    assert r.raw is None
+
+
+def test_parse_envelope_none_stdout_keeps_stderr_diagnostic():
+    """stdout 读失败但 stderr 有料时，优先展示 stderr——原始编码错误才不被兜底文案顶掉。"""
+    r = _parse_envelope(1, None, "UnicodeDecodeError: 'gbk' codec can't decode byte 0x8a")
+    assert not r.ok and r.error_type == "runtime_error"
+    assert "0x8a" in r.final_text
 
 
 def test_missing_agentao_executable_is_runtime_error(tmp_path: Path, monkeypatch):
@@ -134,3 +156,111 @@ def test_poisoned_names_never_expose_values(monkeypatch):
 
     assert "sk-must-not-leak" not in str(poisoned_api_key_names())
     assert "sk-must-not-leak" not in str(drop_poisoned_api_keys())
+
+
+# ───────── 信封编码契约（issue #50：Windows GBK locale 下解码 agentao 输出失败）─────────
+
+
+def test_subprocess_runner_pins_utf8_on_both_ends(tmp_path: Path, monkeypatch):
+    """信封是机器协议：父端解码与子端 std 流**同时**钉 UTF-8，两者缺一不可。
+
+    只钉父端会修好 Windows、却打断 POSIX matched-locale（`LANG=zh_CN.GBK` 下子端仍按 GBK 发）；
+    只钉子端则 POSIX 修好、Windows 父端仍按 CP936 解。故这条断言必须成对。
+    """
+    monkeypatch.delenv("PYTHONUTF8", raising=False)
+    captured: dict = {}
+
+    def fake_run(cmd, **kwargs):
+        captured.update(kwargs)
+        return subprocess.CompletedProcess(cmd, 0, '{"status":"ok","final_text":"答案"}', "")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    r = run_agent_task("q", working_directory=tmp_path, skills=())
+
+    assert r.ok
+    assert captured["encoding"] == "utf-8"  # 父端：不跟 locale 走
+    assert captured["env"]["PYTHONIOENCODING"] == "utf-8"  # 子端：同上
+    # strict 在 Windows 上不可救——异常死在 subprocess 自己的 reader 线程里，父进程 catch 不到，
+    # 只会再次拿到 stdout=None。故 errors 必须是非严格档。
+    assert captured["errors"] == "replace"
+    # 只钉 std 流：PYTHONUTF8 连 fsencoding（argv/文件名口径）一起改，血溅面过大，刻意不设。
+    assert "PYTHONUTF8" not in captured["env"]
+
+
+def test_envelope_child_env_overrides_user_ioencoding(monkeypatch):
+    """用户手设的 `PYTHONIOENCODING=cp936` 会被**覆盖**（非 setdefault）：这条缝是机器协议、
+    不是给人看的控制台，编码不可协商。同时毒空 key 清洗照旧生效（两条清洗叠加、互不吃掉）。"""
+    monkeypatch.setenv("PYTHONIOENCODING", "cp936")
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "")
+    monkeypatch.setenv("DEEPSEEK_API_KEY", "sk-real")
+
+    env = envelope_child_env()
+    assert env["PYTHONIOENCODING"] == "utf-8"
+    assert "ANTHROPIC_API_KEY" not in env
+    assert env["DEEPSEEK_API_KEY"] == "sk-real"
+    assert os.environ["PYTHONIOENCODING"] == "cp936"  # 只换给子进程的副本，不动自己的环境
+
+
+# 在**非 UTF-8 父端 locale**下真起子进程跑一遍 `run_agent_task` 的驱动脚本。
+# 自身 stdout 在该 locale 下就是 ASCII，故结果用默认 `ensure_ascii=True` 转义回传。
+_NON_UTF8_DRIVER = r"""
+import json, locale, os, sys
+from pathlib import Path
+
+sys.path.insert(0, os.environ["GUANLAN_SRC"])
+from guanlan.runtime import run_agent_task
+
+r = run_agent_task("q", working_directory=Path(os.environ["GUANLAN_WD"]), skills=())
+sys.stdout.write(json.dumps({
+    "locale_encoding": locale.getpreferredencoding(False),
+    "ok": r.ok,
+    "final_text": r.final_text,
+}))
+"""
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX-only：假 agentao 靠 shebang 可执行")
+def test_envelope_round_trips_under_non_utf8_parent_locale(tmp_path: Path):
+    """**真管道**回归：父端 locale 非 UTF-8 时，中文信封仍逐字往返（issue #50 的可复现形态）。
+
+    进程内 monkeypatch 造不出这个缺陷——locale 解码档在解释器启动时就定了（同理见 backlog
+    §1.③）。故此处真起一个 `LC_ALL=C` + `-X utf8=0` 的解释器（父端 locale 编码 = ASCII，
+    与 Windows CP936 同构：**父端 locale 解不动子端发来的 UTF-8**），PATH 上摆一个只吐 UTF-8
+    字节的假 agentao。修复前：`text=True` 按 ASCII 解 → `UnicodeDecodeError` 冒出 `subprocess.run`
+    （POSIX 形态）→ 驱动非零退出；修复后：父端钉 UTF-8 → 中文原样回来。
+    """
+    expected = "已摄入《测试文档》，新建 3 页。"
+    payload = json.dumps({"status": "ok", "final_text": expected}, ensure_ascii=False)
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    fake = bin_dir / "agentao"
+    # 假 agentao 走 `stdout.buffer` 直发 UTF-8 字节——正是 agentao 真身在钉死编码后的行为，
+    # 且脚本源码全 ASCII，不把测试自身的写盘编码也搅进来。
+    fake.write_text(
+        f"#!{sys.executable}\nimport sys\nsys.stdout.buffer.write({payload.encode()!r})\n",
+        encoding="ascii",
+    )
+    fake.chmod(0o755)
+
+    env = dict(os.environ)
+    env["PATH"] = f"{bin_dir}{os.pathsep}{env.get('PATH', '')}"
+    env["LC_ALL"] = env["LANG"] = "C"
+    env["PYTHONCOERCECLOCALE"] = "0"  # 挡掉 PEP 538 把 C locale 强升成 C.UTF-8
+    env.pop("PYTHONUTF8", None)  # PEP 540 UTF-8 模式会让整个用例退化成空跑
+    env.pop("PYTHONIOENCODING", None)
+    env["GUANLAN_SRC"] = str(Path(guanlan.__file__).resolve().parent.parent)
+    env["GUANLAN_WD"] = str(tmp_path)
+
+    proc = subprocess.run(
+        [sys.executable, "-X", "utf8=0", "-c", _NON_UTF8_DRIVER],
+        env=env,
+        capture_output=True,
+        encoding="utf-8",
+        errors="replace",
+    )
+    assert proc.returncode == 0, f"驱动异常退出：\n{proc.stderr}"
+    got = json.loads(proc.stdout)
+    if "utf" in got["locale_encoding"].lower():  # 造不出非 UTF-8 父端 → 诚实跳过，不静默空跑
+        pytest.skip(f"本环境的父端 locale 仍是 {got['locale_encoding']}，无法复现该缺陷")
+    assert got["ok"]
+    assert got["final_text"] == expected


### PR DESCRIPTION
Fixes #50

`agentao run --format json` 的 stdout 是**机器协议**，此前两端都没约定编码、各自跟 locale 走，于是只在「父子 locale 恰好一致」时侥幸成立：

| 环境 | 子端（agentao）实际编码 | 父端（`text=True`）解码 | 结果 |
|---|---|---|---|
| Windows + CP936 | **UTF-8**（agentao `_ensure_utf8()` 只在 win32 强制） | GBK（locale） | ❌ 失配 |
| POSIX + UTF-8 locale | UTF-8 | UTF-8 | ✅ CI 只覆盖这一格 |
| POSIX + `LANG=zh_CN.GBK` | GBK（locale） | GBK（locale） | ✅ matched-locale 侥幸 |

## 两点比 issue 里更严重

**崩溃只是少数派。** 中文信封的 UTF-8 字节按 GBK 解，约 1/3 撞上非法序列（报告里那条 `UnicodeDecodeError`），另约 2/3 **静默解成乱码而 `json.loads` 照样成功**——JSON 骨架全是 ASCII、撑得住，死的只有中文正文。于是 `query` 会以**退出码 0 交付一段乱码答案**，这一半从来不会被谁注意到。

**影响面不止 `ingest`。** 这条缝是**所有** LLM 命令的唯一入口：`ingest` / `query` / `heal` / `audit`、Web 作业、MCP 的 `query` 工具。且异常路径会**绕过写门禁**——`run_agent_task` 抛异常时 `enforce_write_result` 根本不执行，那次运行的 `raw/` 只读快照比对一条都没跑。

## 改了什么

**① 两端一起钉 UTF-8** —— 父端 `encoding="utf-8"`，子端经新增的 `envelope_child_env()` 传 `PYTHONIOENCODING`。

- **必须成对**：只钉父端会修好 Windows、却打断 POSIX matched-locale（子端仍按 GBK 发）。这个坑 `convert.py` 已经踩过一次并回退过，见 backlog §1.③/§2.4b「须两端协同」。**`convert.py` 本次不动**——那条缝的对端是裸 `print` 的 skill 脚本，与本接缝不同构。
- **是 `PYTHONIOENCODING` 不是 `PYTHONUTF8`**：后者连 fsencoding（argv/文件名口径）一起改，血溅面远大于这条协议缝。
- 用户手设的 `PYTHONIOENCODING=cp936` 会被**覆盖**（非 setdefault）：这条缝是机器协议、不是给人看的控制台。

**② `errors="replace"`** —— 不是「怕出错就 replace」的懒惰档，是 Windows 上唯一可控的档：`capture_output` 在 Windows 走 `_readerthread`，strict 解码抛的异常**死在 subprocess 内部线程里**，父进程 `try/except` 够不着，只会再次拿到 `proc.stdout is None`。issue 建议的「保持 strict、捕获 `UnicodeDecodeError`」在 Windows 上走不通。

**③ `_parse_envelope` 兜底** —— 收 `str | None`、归一空串、`TypeError` 纳入 except，读不到 stdout 时给一句人话诊断而非让二次异常盖掉真因。docstring 里写明**这只是错误呈现层的兜底**，真修是①；留着它是因为「读不到 stdout」不止编码一种成因。

## 测试（3 层，5 条新用例）

- **契约断言**（跨平台常绿、不 skip）：monkeypatch `subprocess.run`，成对断言父端 `encoding`/`errors` + 子端 `env["PYTHONIOENCODING"]`，并断言**不注入** `PYTHONUTF8`；另一条守 `PYTHONIOENCODING=cp936` 被覆盖且毒空 key 清洗不被吃掉。
- **单测**：`_parse_envelope(0, None, None)` → `runtime_error`；stderr 有料时优先展示 stderr。
- **真管道**：`LC_ALL=C` + `-X utf8=0` 的真子解释器（父端 locale 编码 = ASCII，**与 Windows CP936 同构**），PATH 上摆一个只吐 UTF-8 字节的假 agentao。进程内 monkeypatch 造不出这个缺陷（locale 解码档在解释器启动时就定了，同 backlog §1.③）；造不出非 UTF-8 父端的环境**诚实 skip**、不静默空跑。

**负向对照已跑**：临时撤掉父端 `encoding=` 后，这两条用例即以报告中的形态失败——`UnicodeDecodeError: 'ascii' codec can't decode byte 0xe5` 从 `subprocess.run` 的 `communicate()` 冒出。恢复后全绿。

```
tests/test_runtime.py          16 passed
全量                           1425 passed, 1 skipped（skip 是既有的飞书真 SDK 探针）
uvx ruff check guanlan tests   All checks passed!
```

## 不在本 PR 范围

- **CI 补 3.13 / 窄 Windows job / classifiers 补 3.13**：issue 建议的回归环境。是 workflow 层改动、要单独判断 Windows 矩阵的成本，故不在此顺带。本 PR 的契约测试与真管道测试在现有 ubuntu 矩阵上就能守住这条缺陷。
- **`convert.py` 的 drain 线程容错**：issue 末段提到的关联风险成立（线程遇 `UnicodeDecodeError` 静默死掉 → stdout 为空 → 抛出「成功退出但未输出产物路径」这种误导文案），但真修法要连 skill 端一起动（backlog §2.4b），值得独立 issue。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
