### PR TITLE
chore: 回开发态 0.1.22 → 0.1.23.dev0 (两-PR 发版仪式第二步)

### DIFF
--- a/guanlan/__init__.py
+++ b/guanlan/__init__.py
@@ -4,4 +4,4 @@ P1 交付 `guanlan init`（确定性生成最小模板）。ingest / query 等 L
 由 `guanlan-wiki` skill 驱动 Agentao 完成；本包只做编排与确定性门禁。
 """
 
-__version__ = "0.1.22"
+__version__ = "0.1.23.dev0"


### PR DESCRIPTION
v0.1.22 已发布并验证完毕：

| 项 | 结果 |
|---|---|
| tag | `v0.1.22` → `a60aa4e`（合并后的 main 提交，非 PR 分支） |
| PyPI | 隔离 venv `--no-cache` 钉版本装成，`guanlan --version` → `0.1.22` |
| GitHub Release | [v0.1.22](https://github.com/jin-bo/guanlan/releases/tag/v0.1.22)，notes 抽的是真正的 CHANGELOG `[0.1.22]` 段（非占位），末尾带 compare 链接 |
| 冒烟 | 五个宿主子命令 `--help` 全起得来；`lark-oapi 1.7.2` / `mcp 2.0.0` 满足下限；装出来的包上 `init` + `check` 跑通 |

按仪式**只改版本号一行**，CHANGELOG 不动——`[未发布]` 段等下一个变更落地再加。

🤖 Generated with [Claude Code](https://claude.com/claude-code)