### PR TITLE
chore: 回开发态 0.1.23 → 0.1.24.dev0 (两-PR 发版仪式第二步)

### DIFF
--- a/guanlan/__init__.py
+++ b/guanlan/__init__.py
@@ -4,4 +4,4 @@ P1 交付 `guanlan init`（确定性生成最小模板）。ingest / query 等 L
 由 `guanlan-wiki` skill 驱动 Agentao 完成；本包只做编排与确定性门禁。
 """
 
-__version__ = "0.1.23"
+__version__ = "0.1.24.dev0"


### PR DESCRIPTION
两-PR 发版仪式第二步。承 #57 与 tag `v0.1.23`。

只改 `guanlan/__init__.py` 一行：`0.1.23` → `0.1.24.dev0`。

**CHANGELOG 不动**——`[未发布]` 段等下一个变更落地再加。提前放一个空段等于给 `release.yml` 的 awk 抽取埋一个空 notes。

## v0.1.23 发布状态

- PyPI：https://pypi.org/project/guanlan-wiki/0.1.23/
- GitHub Release：由 `release.yml` 自动建，notes 4505 字（从 CHANGELOG 抽取成功，不是回退占位）
- 装包验证：隔离 venv + `--no-cache` 钉版本，`guanlan --version` → `0.1.23`；`pageview` / `delivery` / `feishu` / `web.app` / `mcp` 全部导入成功（在仓外跑，避开本地源码树）

首次装时撞上文档里记的索引延迟（`/simple` 比 JSON API 慢半拍），轮询 JSON API 到位后重试即通——口径与 `docs/发布到-PyPI.md` 一致，无需改文档。

🤖 Generated with [Claude Code](https://claude.com/claude-code)